### PR TITLE
Sentry Context Middleware

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -36,6 +36,7 @@ class Kernel extends HttpKernel
             \Illuminate\View\Middleware\ShareErrorsFromSession::class,
             \App\Http\Middleware\VerifyCsrfToken::class,
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
+            \App\Http\Middleware\SetTenant::class,
             \App\Http\Middleware\SentryContext::class,
         ],
     ];

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -36,6 +36,7 @@ class Kernel extends HttpKernel
             \Illuminate\View\Middleware\ShareErrorsFromSession::class,
             \App\Http\Middleware\VerifyCsrfToken::class,
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
+            \App\Http\Middleware\SentryContext::class,
         ],
     ];
 

--- a/app/Http/Middleware/SentryContext.php
+++ b/app/Http/Middleware/SentryContext.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Models\User;
+use App\Services\TenantManager\TenantManager;
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Sentry\State\Scope;
+use Sentry\UserDataBag;
+use Symfony\Component\HttpFoundation\Response;
+
+class SentryContext
+{
+    /**
+     * @var TenantManager $tenantManager
+     */
+    private TenantManager $tenantManager;
+
+    public function __construct(TenantManager $tenantManager)
+    {
+        $this->tenantManager = $tenantManager;
+    }
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(Request): (Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        /**
+         * @var User|null $user
+         */
+        $user = Auth::user();
+
+        if (app()->bound('sentry')) {
+            \Sentry\configureScope(function (Scope $scope) use ($request, $user): void {
+
+                $scope->setContext('tenant', [
+                   'name' =>  $this->tenantManager->getCurrentTenant()->label(),
+                ]);
+
+                if ($user !== null) {
+                    $userDataBag = new UserDataBag(
+                        id: $user->id,
+                        email: $user->email,
+                        ipAddress: $request->ip(),
+                        username: $user->name,
+                    );
+
+                    $scope->setUser($userDataBag);
+                }
+            });
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Http/Middleware/SentryContext.php
+++ b/app/Http/Middleware/SentryContext.php
@@ -13,7 +13,6 @@ use Symfony\Component\HttpFoundation\Response;
 
 class SentryContext
 {
-
     public function __construct(private readonly TenantManager $tenantManager)
     {
         //

--- a/app/Http/Middleware/SentryContext.php
+++ b/app/Http/Middleware/SentryContext.php
@@ -13,14 +13,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 class SentryContext
 {
-    /**
-     * @var TenantManager $tenantManager
-     */
-    private TenantManager $tenantManager;
 
-    public function __construct(TenantManager $tenantManager)
+    public function __construct(private readonly TenantManager $tenantManager)
     {
-        $this->tenantManager = $tenantManager;
+        //
     }
 
     /**
@@ -47,8 +43,9 @@ class SentryContext
                         id: $user->id,
                         email: $user->email,
                         ipAddress: $request->ip(),
-                        username: $user->name,
                     );
+
+                    $userDataBag->setMetadata('Name', $user->name);
 
                     $scope->setUser($userDataBag);
                 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use App\Models\Traits\HasUuid;
 use Carbon\CarbonImmutable;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Propaganistas\LaravelPhone\Casts\E164PhoneNumberCast;
@@ -20,6 +21,8 @@ use Propaganistas\LaravelPhone\PhoneNumber;
  * @property string|null $company_name
  * @property PhoneNumber|null $phone
  * @property boolean $marketing_opt_in
+ *
+ * @property-read string $name
  */
 class User extends Authenticatable
 {
@@ -42,4 +45,14 @@ class User extends Authenticatable
         'marketing_opt_in' => 'boolean',
         'phone'            => E164PhoneNumberCast::class,
     ];
+
+    /**
+     * @return Attribute<string, never>
+     */
+    public function name(): Attribute
+    {
+        return new Attribute(
+            get: fn() => trim($this->first_name . ' ' . $this->last_name)
+        );
+    }
 }

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -22,7 +22,7 @@ class RouteServiceProvider extends ServiceProvider
         $this->routes(function () {
             // Web Routes
             Route::name('web.')
-                ->middleware(['set_tenant', 'web'])
+                ->middleware(['web'])
                 ->group(base_path('routes/web.php'));
         });
     }

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -2,10 +2,7 @@
 
 namespace App\Providers;
 
-use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
-use Illuminate\Http\Request;
-use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Facades\Route;
 
 class RouteServiceProvider extends ServiceProvider
@@ -25,7 +22,7 @@ class RouteServiceProvider extends ServiceProvider
         $this->routes(function () {
             // Web Routes
             Route::name('web.')
-                ->middleware(['web', 'set_tenant'])
+                ->middleware(['set_tenant', 'web'])
                 ->group(base_path('routes/web.php'));
         });
     }


### PR DESCRIPTION
I've rearranged the tenant middleware to run before the web group of middleware so that we can get the tenant in the Sentry middleware.

It would be nice to include the widget name as well but as it is currently only the space calculator I decided to avoid doing this for now. It might be good to add that once we start adding another widget (though you could probably guess it from the URL in the email / error logs).

This is the first time I've set up a Sentry Context middleware so interested to know if we can add anything else to this? I used Tower and RSO as inspiration. 