### PR TITLE
Skeleton Layout Implementation

### DIFF
--- a/app/Http/Controllers/Web/SpaceCalculator/LandingController.php
+++ b/app/Http/Controllers/Web/SpaceCalculator/LandingController.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Controllers\Web\SpaceCalculator;
+
+use App\Http\Controllers\WebController;
+use Illuminate\View\View;
+
+class LandingController extends WebController
+{
+    /**
+     * @return View
+     */
+    public function getLanding(): View
+    {
+        // todo: discuss - redefine meta title (defer for now)
+        $this->metaTitle('Space Calculator Landing Page');
+
+        return view('web.space-calculator.landing', [
+            //
+        ]);
+    }
+}

--- a/app/Http/Controllers/Web/SpaceCalculator/LandingController.php
+++ b/app/Http/Controllers/Web/SpaceCalculator/LandingController.php
@@ -10,10 +10,9 @@ class LandingController extends WebController
     /**
      * @return View
      */
-    public function getLanding(): View
+    public function getIndex(): View
     {
-        // todo: discuss - redefine meta title (defer for now)
-        $this->metaTitle('Space Calculator Landing Page');
+        $this->metaTitle('Space Calculator');
 
         return view('web.space-calculator.landing', [
             //

--- a/app/View/Components/Footer.php
+++ b/app/View/Components/Footer.php
@@ -6,7 +6,7 @@ use App\Services\TenantManager\TenantManager;
 use Illuminate\Contracts\View\View;
 use Illuminate\View\Component;
 
-class Header extends Component
+class Footer extends Component
 {
     /**
      * Create a new component instance.
@@ -21,7 +21,7 @@ class Header extends Component
      */
     public function render(): View
     {
-        return view('components.header', [
+        return view('components.footer', [
             'tenant' => $this->tenantManager->getCurrentTenant(),
         ]);
     }

--- a/app/View/Components/Header.php
+++ b/app/View/Components/Header.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\View\Components;
+
+use App\Services\TenantManager\TenantManager;
+use Closure;
+use Illuminate\Contracts\View\View;
+use Illuminate\View\Component;
+
+class Header extends Component
+{
+    /**
+     * Create a new component instance.
+     */
+    public function __construct(private readonly TenantManager $tenantManager)
+    {
+        //
+    }
+
+    /**
+     * Get the view / contents that represent the component.
+     */
+    public function render(): View|Closure|string
+    {
+        return view('components.header', [
+            'tenant' => $this->tenantManager->getCurrentTenant(),
+        ]);
+    }
+}

--- a/resources/views/components/footer.blade.php
+++ b/resources/views/components/footer.blade.php
@@ -1,0 +1,8 @@
+<footer>
+    <div>
+        <a href="/" title="{{ $tenant->label() }}">
+            {{ $tenant->label() }}
+        </a>
+        <span>&copy; {{ date('Y') }}</span>
+    </div>
+</footer>

--- a/resources/views/components/header.blade.php
+++ b/resources/views/components/header.blade.php
@@ -1,0 +1,17 @@
+<header>
+    <div>
+        <div> {{-- todo: discuss - would it be better to just link to the space calculator for now or leave it like this? (eventually this would redirect to the space calculator) --}}
+            <a href="/" title="{{ $tenant->label() }}">
+                <img src="{{ $tenant->logoFilePath() }}" alt="{{ $tenant->label() }}" />
+            </a>
+        </div>
+        <div>
+            {{-- space for menu here? (based on MPMR layout) --}}
+        </div>
+        <div>
+            @if(\Auth::check())
+                Hello {{ \Auth::user()->name }}!
+            @endif
+        </div>
+    </div>
+</header>

--- a/resources/views/components/header.blade.php
+++ b/resources/views/components/header.blade.php
@@ -1,6 +1,6 @@
 <header>
     <div>
-        <div> {{-- todo: discuss - would it be better to just link to the space calculator for now or leave it like this? (eventually this would redirect to the space calculator) --}}
+        <div>
             <a href="/" title="{{ $tenant->label() }}">
                 <img src="{{ $tenant->logoFilePath() }}" alt="{{ $tenant->label() }}" />
             </a>
@@ -10,7 +10,7 @@
         </div>
         <div>
             @if(\Auth::check())
-                Hello {{ \Auth::user()->name }}!
+                Hello {{ Auth::user()->name }}!
             @endif
         </div>
     </div>

--- a/resources/views/skeleton.blade.php
+++ b/resources/views/skeleton.blade.php
@@ -13,6 +13,8 @@
 
 @yield('page')
 
+<x-footer />
+
 @vite(['resources/js/app.js'])
 
 @stack('scripts')

--- a/resources/views/skeleton.blade.php
+++ b/resources/views/skeleton.blade.php
@@ -9,6 +9,8 @@
 </head>
 <body>
 
+<x-header />
+
 @yield('page')
 
 @vite(['resources/js/app.js'])

--- a/resources/views/web/space-calculator/landing.blade.php
+++ b/resources/views/web/space-calculator/landing.blade.php
@@ -1,0 +1,5 @@
+@extends('skeleton')
+
+@section('page')
+    {{-- page used to demo skeleton layout --}}
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -7,16 +7,9 @@ use Illuminate\Support\Facades\Route;
  *------------------- GUEST & AUTHENTICATED ROUTES --------------------*
  *---------------------------------------------------------------------*/
 
-Route::group([
-    'middleware'    => [
-        'web'
-    ]
-], function (): void {
-
-    Route::group(['prefix' => 'space-calculator'], function (): void {
-        Route::get('/', [Web\SpaceCalculator\LandingController::class, 'getLanding'])
-            ->name('space_calculator.landing');
-    });
+Route::group(['prefix' => 'space-calculator'], function (): void {
+    Route::get('/', [Web\SpaceCalculator\LandingController::class, 'getIndex'])
+        ->name('space-calculator.index');
 });
 
 /*---------------------------------------------------------------------*

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,11 +1,23 @@
 <?php
 
+use App\Http\Controllers\Web;
 use Illuminate\Support\Facades\Route;
 
 /*---------------------------------------------------------------------*
  *------------------- GUEST & AUTHENTICATED ROUTES --------------------*
  *---------------------------------------------------------------------*/
 
+Route::group([
+    'middleware'    => [
+        'web'
+    ]
+], function (): void {
+
+    Route::group(['prefix' => 'space-calculator'], function (): void {
+        Route::get('/', [Web\SpaceCalculator\LandingController::class, 'getLanding'])
+            ->name('space_calculator.landing');
+    });
+});
 
 /*---------------------------------------------------------------------*
  *--------------------------- GUEST ROUTES ----------------------------*


### PR DESCRIPTION
I have gone a step ahead and added a route for the Space Calculator landing page just so we can see the skeleton in the browser. I will expand upon this when I come to tackle the card for it.

The header and footer have been added to the skeleton file which at the moment is just HTML without styling. There are some notes in the code for consideration.

I have built the HTML loosely based on the layout of the MPMR header and footer but tried to keep it minimal as this may all just change when the design comes in.