### PR TITLE
Space Calculator Output Structure

### DIFF
--- a/app/Services/SpaceCalculator/Calculator.php
+++ b/app/Services/SpaceCalculator/Calculator.php
@@ -16,6 +16,13 @@ class Calculator
      */
     public function calculate(Inputs $inputs): Output
     {
-        return new Output();
+        // adding classes with empty results for now for Larastan and tests while we are only doing the structure
+        // todo: real calculations!
+
+        $areaSize = new OutputAreaSize(0, 0, 0, 0, 0, 0);
+
+        return new Output(
+            areaSize: $areaSize,
+        );
     }
 }

--- a/app/Services/SpaceCalculator/Calculator.php
+++ b/app/Services/SpaceCalculator/Calculator.php
@@ -22,11 +22,13 @@ class Calculator
         $areaSize = new OutputAreaSize(0, 0, 0, 0, 0, 0);
         $assets = collect();
         $capacityTypes = collect();
+        $areaTypes = collect();
 
         return new Output(
             areaSize: $areaSize,
             assets: $assets,
             capacityTypes: $capacityTypes,
+            areaTypes: $areaTypes,
         );
     }
 }

--- a/app/Services/SpaceCalculator/Calculator.php
+++ b/app/Services/SpaceCalculator/Calculator.php
@@ -21,10 +21,12 @@ class Calculator
 
         $areaSize = new OutputAreaSize(0, 0, 0, 0, 0, 0);
         $assets = collect();
+        $capacityTypes = collect();
 
         return new Output(
             areaSize: $areaSize,
             assets: $assets,
+            capacityTypes: $capacityTypes,
         );
     }
 }

--- a/app/Services/SpaceCalculator/Calculator.php
+++ b/app/Services/SpaceCalculator/Calculator.php
@@ -20,9 +20,11 @@ class Calculator
         // todo: real calculations!
 
         $areaSize = new OutputAreaSize(0, 0, 0, 0, 0, 0);
+        $assets = collect();
 
         return new Output(
             areaSize: $areaSize,
+            assets: $assets,
         );
     }
 }

--- a/app/Services/SpaceCalculator/Calculator.php
+++ b/app/Services/SpaceCalculator/Calculator.php
@@ -2,10 +2,10 @@
 
 namespace App\Services\SpaceCalculator;
 
-class Calculator
+readonly class Calculator
 {
    /** @phpstan-ignore-next-line */ // todo: set up config vars later and remove phpstan comment
-    public function __construct(private readonly Config $config)
+    public function __construct(private Config $config)
     {
         //
     }

--- a/app/Services/SpaceCalculator/Config.php
+++ b/app/Services/SpaceCalculator/Config.php
@@ -2,7 +2,7 @@
 
 namespace App\Services\SpaceCalculator;
 
-class Config
+readonly class Config
 {
     public function __construct()
     {

--- a/app/Services/SpaceCalculator/Inputs.php
+++ b/app/Services/SpaceCalculator/Inputs.php
@@ -7,16 +7,16 @@ use App\Enums\Widgets\SpaceCalculator\HybridWorking;
 use App\Enums\Widgets\SpaceCalculator\Mobility;
 use App\Enums\Widgets\SpaceCalculator\Workstyle;
 
-class Inputs
+readonly class Inputs
 {
     public function __construct(
-        public readonly Workstyle $workstyle,
-        public readonly int $totalPeople,
-        public readonly int $growthPercentage,
-        public readonly int $deskPercentage,
-        public readonly HybridWorking $hybridWorking,
-        public readonly Mobility $mobility,
-        public readonly Collaboration $collaboration,
+        public Workstyle $workstyle,
+        public int $totalPeople,
+        public int $growthPercentage,
+        public int $deskPercentage,
+        public HybridWorking $hybridWorking,
+        public Mobility $mobility,
+        public Collaboration $collaboration,
     ) {
     }
 }

--- a/app/Services/SpaceCalculator/Output.php
+++ b/app/Services/SpaceCalculator/Output.php
@@ -4,7 +4,7 @@ namespace App\Services\SpaceCalculator;
 
 use Illuminate\Support\Collection;
 
-class Output
+readonly class Output
 {
     /**
      * @param OutputAreaSize $areaSize
@@ -13,10 +13,10 @@ class Output
      * @param Collection<int, OutputAreaType> $areaTypes
      */
     public function __construct(
-        public readonly OutputAreaSize $areaSize,
-        public readonly Collection $assets,
-        public readonly Collection $capacityTypes,
-        public readonly Collection $areaTypes,
+        public OutputAreaSize $areaSize,
+        public Collection $assets,
+        public Collection $capacityTypes,
+        public Collection $areaTypes,
     ) {
     }
 }

--- a/app/Services/SpaceCalculator/Output.php
+++ b/app/Services/SpaceCalculator/Output.php
@@ -4,8 +4,12 @@ namespace App\Services\SpaceCalculator;
 
 class Output
 {
-    public function __construct()
-    {
-        // output vars to be set up here
+    /**
+     * @param OutputAreaSize $areaSize
+     */
+    public function __construct(
+        public readonly OutputAreaSize $areaSize,
+    ) {
+        //
     }
 }

--- a/app/Services/SpaceCalculator/Output.php
+++ b/app/Services/SpaceCalculator/Output.php
@@ -10,11 +10,13 @@ class Output
      * @param OutputAreaSize $areaSize
      * @param Collection<int, OutputAsset> $assets
      * @param Collection<int, OutputCapacityType> $capacityTypes
+     * @param Collection<int, OutputAreaType> $areaTypes
      */
     public function __construct(
         public readonly OutputAreaSize $areaSize,
         public readonly Collection $assets,
         public readonly Collection $capacityTypes,
+        public readonly Collection $areaTypes,
     ) {
     }
 }

--- a/app/Services/SpaceCalculator/Output.php
+++ b/app/Services/SpaceCalculator/Output.php
@@ -2,14 +2,17 @@
 
 namespace App\Services\SpaceCalculator;
 
+use Illuminate\Support\Collection;
+
 class Output
 {
     /**
      * @param OutputAreaSize $areaSize
+     * @param Collection<int, OutputAsset> $assets
      */
     public function __construct(
         public readonly OutputAreaSize $areaSize,
+        public readonly Collection $assets,
     ) {
-        //
     }
 }

--- a/app/Services/SpaceCalculator/Output.php
+++ b/app/Services/SpaceCalculator/Output.php
@@ -9,10 +9,12 @@ class Output
     /**
      * @param OutputAreaSize $areaSize
      * @param Collection<int, OutputAsset> $assets
+     * @param Collection<int, OutputCapacityType> $capacityTypes
      */
     public function __construct(
         public readonly OutputAreaSize $areaSize,
         public readonly Collection $assets,
+        public readonly Collection $capacityTypes,
     ) {
     }
 }

--- a/app/Services/SpaceCalculator/OutputAreaSize.php
+++ b/app/Services/SpaceCalculator/OutputAreaSize.php
@@ -13,12 +13,12 @@ class OutputAreaSize
      * @param int $spaciousSqM
      */
     public function __construct(
-        public int $tightSqFt,
-        public int $tightSqM,
-        public int $averageSqFt,
-        public int $averageSqM,
-        public int $spaciousSqFt,
-        public int $spaciousSqM,
+        public readonly int $tightSqFt,
+        public readonly int $tightSqM,
+        public readonly int $averageSqFt,
+        public readonly int $averageSqM,
+        public readonly int $spaciousSqFt,
+        public readonly int $spaciousSqM,
     ) {
         //
     }

--- a/app/Services/SpaceCalculator/OutputAreaSize.php
+++ b/app/Services/SpaceCalculator/OutputAreaSize.php
@@ -13,12 +13,12 @@ class OutputAreaSize
      * @param int $spaciousSqM
      */
     public function __construct(
-        public readonly int $tightSqFt,
-        public readonly int $tightSqM,
-        public readonly int $averageSqFt,
-        public readonly int $averageSqM,
-        public readonly int $spaciousSqFt,
-        public readonly int $spaciousSqM,
+        public int $tightSqFt,
+        public int $tightSqM,
+        public int $averageSqFt,
+        public int $averageSqM,
+        public int $spaciousSqFt,
+        public int $spaciousSqM,
     ) {
         //
     }

--- a/app/Services/SpaceCalculator/OutputAreaSize.php
+++ b/app/Services/SpaceCalculator/OutputAreaSize.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Services\SpaceCalculator;
+
+class OutputAreaSize
+{
+    /**
+     * @param int $tightSqFt
+     * @param int $tightSqM
+     * @param int $averageSqFt
+     * @param int $averageSqM
+     * @param int $spaciousSqFt
+     * @param int $spaciousSqM
+     */
+    public function __construct(
+        public readonly int $tightSqFt,
+        public readonly int $tightSqM,
+        public readonly int $averageSqFt,
+        public readonly int $averageSqM,
+        public readonly int $spaciousSqFt,
+        public readonly int $spaciousSqM,
+    ) {
+        //
+    }
+}

--- a/app/Services/SpaceCalculator/OutputAreaSize.php
+++ b/app/Services/SpaceCalculator/OutputAreaSize.php
@@ -2,7 +2,7 @@
 
 namespace App\Services\SpaceCalculator;
 
-class OutputAreaSize
+readonly class OutputAreaSize
 {
     /**
      * @param int $tightSqFt
@@ -13,12 +13,12 @@ class OutputAreaSize
      * @param int $spaciousSqM
      */
     public function __construct(
-        public readonly int $tightSqFt,
-        public readonly int $tightSqM,
-        public readonly int $averageSqFt,
-        public readonly int $averageSqM,
-        public readonly int $spaciousSqFt,
-        public readonly int $spaciousSqM,
+        public int $tightSqFt,
+        public int $tightSqM,
+        public int $averageSqFt,
+        public int $averageSqM,
+        public int $spaciousSqFt,
+        public int $spaciousSqM,
     ) {
         //
     }

--- a/app/Services/SpaceCalculator/OutputAreaType.php
+++ b/app/Services/SpaceCalculator/OutputAreaType.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Services\SpaceCalculator;
+
+use App\Enums\Widgets\SpaceCalculator\AreaType;
+
+class OutputAreaType
+{
+    /**
+     * @param AreaType $areaType
+     * @param int $quantity
+     */
+    public function __construct(
+        public readonly AreaType $areaType,
+        public readonly int $quantity,
+    ) {
+        //
+    }
+}

--- a/app/Services/SpaceCalculator/OutputAreaType.php
+++ b/app/Services/SpaceCalculator/OutputAreaType.php
@@ -4,15 +4,15 @@ namespace App\Services\SpaceCalculator;
 
 use App\Enums\Widgets\SpaceCalculator\AreaType;
 
-class OutputAreaType
+readonly class OutputAreaType
 {
     /**
      * @param AreaType $areaType
      * @param int $quantity
      */
     public function __construct(
-        public readonly AreaType $areaType,
-        public readonly int $quantity,
+        public AreaType $areaType,
+        public int $quantity,
     ) {
         //
     }

--- a/app/Services/SpaceCalculator/OutputAsset.php
+++ b/app/Services/SpaceCalculator/OutputAsset.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Services\SpaceCalculator;
+
+use App\Enums\Widgets\SpaceCalculator\Asset;
+
+class OutputAsset
+{
+    /**
+     * @param Asset $asset
+     * @param int $quantity
+     */
+    public function __construct(
+        public Asset $asset,
+        public int $quantity,
+    ) {
+        //
+    }
+}

--- a/app/Services/SpaceCalculator/OutputAsset.php
+++ b/app/Services/SpaceCalculator/OutputAsset.php
@@ -4,15 +4,15 @@ namespace App\Services\SpaceCalculator;
 
 use App\Enums\Widgets\SpaceCalculator\Asset;
 
-class OutputAsset
+readonly class OutputAsset
 {
     /**
      * @param Asset $asset
      * @param int $quantity
      */
     public function __construct(
-        public readonly Asset $asset,
-        public readonly int $quantity,
+        public Asset $asset,
+        public int $quantity,
     ) {
         //
     }

--- a/app/Services/SpaceCalculator/OutputCapacityType.php
+++ b/app/Services/SpaceCalculator/OutputCapacityType.php
@@ -4,15 +4,15 @@ namespace App\Services\SpaceCalculator;
 
 use App\Enums\Widgets\SpaceCalculator\CapacityType;
 
-class OutputCapacityType
+readonly class OutputCapacityType
 {
     /**
      * @param CapacityType $capacityType
      * @param int $quantity
      */
     public function __construct(
-        public readonly CapacityType $capacityType,
-        public readonly int $quantity,
+        public CapacityType $capacityType,
+        public int $quantity,
     ) {
         //
     }

--- a/app/Services/SpaceCalculator/OutputCapacityType.php
+++ b/app/Services/SpaceCalculator/OutputCapacityType.php
@@ -2,16 +2,16 @@
 
 namespace App\Services\SpaceCalculator;
 
-use App\Enums\Widgets\SpaceCalculator\Asset;
+use App\Enums\Widgets\SpaceCalculator\CapacityType;
 
-class OutputAsset
+class OutputCapacityType
 {
     /**
-     * @param Asset $asset
+     * @param CapacityType $capacityType
      * @param int $quantity
      */
     public function __construct(
-        public readonly Asset $asset,
+        public readonly CapacityType $capacityType,
         public readonly int $quantity,
     ) {
         //


### PR DESCRIPTION
This is for the structure of the classes that make up the output based on the spreadsheet. 

I've made the attributes on each class `readonly` and also the properties on the `Output` class. PHPStorm tells me I can make the classes `readonly` which would then mean I don't have to make these attributes `readonly` since that becomes redundant. However, when I do that codesniffer has a warning come up. Can we discuss this later on?

I thought about adding the properties to the test for the `calculate()` function on the `Calculator` class but I didn't since they are just providing placeholder / empty values for now - it would be better to add these when we have the actual calculations set up.