### PR TITLE
Asset Outputs

### DIFF
--- a/app/Enums/Widgets/SpaceCalculator/WorkstationType.php
+++ b/app/Enums/Widgets/SpaceCalculator/WorkstationType.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Enums\Widgets\SpaceCalculator;
+
+use App\Enums\Contracts\HasLabel;
+
+enum WorkstationType: string implements HasLabel
+{
+    case PRIVATE_OFFICES = 'private-offices';
+    case OPEN_PLAN_DESKS = 'open-plan-desks';
+    case OPEN_PLAN_TOUCHDOWN_DESKS = 'open-plan-touchdown-desks';
+
+    /**
+     * @return string
+     */
+    public function label(): string
+    {
+        return match ($this) {
+            self::PRIVATE_OFFICES => 'Private Offices',
+            self::OPEN_PLAN_DESKS => 'Open Plan Desks',
+            self::OPEN_PLAN_TOUCHDOWN_DESKS => 'Open Plan Touchdown Desks',
+        };
+    }
+}

--- a/app/Services/SpaceCalculator/Calculator.php
+++ b/app/Services/SpaceCalculator/Calculator.php
@@ -520,16 +520,19 @@ class Calculator
                 )
             );
         }
-        /*$assets = $assets->merge(
+        $assets = $assets->merge(
             $assetCalculations->where('quantity', '!=', 0)
-                ->map(function(AssetCalculation $assetCalculation, string $key): OutputAsset {
+                ->map(function (AssetCalculation $assetCalculation, string $key): OutputAsset {
+                    /**
+                     * @var int $quantity
+                     */
+                    $quantity = $assetCalculation->quantity;
                     return new OutputAsset(
                         Asset::from($key),
-                        $assetCalculation->quantity,
+                        $quantity,
                     );
                 })
-        );*/
-//dd($assets);
+        );
 
         return new Output(
             areaSize: $areaSize,

--- a/app/Services/SpaceCalculator/Calculator.php
+++ b/app/Services/SpaceCalculator/Calculator.php
@@ -497,27 +497,21 @@ class Calculator
         $assets = collect();
 
         if ($privateOffices != 0) {
-            $assets->push(
-                new OutputAsset(
-                    WorkstationType::PRIVATE_OFFICES,
-                    (int) round($privateOffices),
-                )
+            $assets[WorkstationType::PRIVATE_OFFICES->value] = new OutputAsset(
+                WorkstationType::PRIVATE_OFFICES,
+                (int) round($privateOffices),
             );
         }
         if ($openPlanDesks != 0) {
-            $assets->push(
-                new OutputAsset(
-                    WorkstationType::OPEN_PLAN_DESKS,
-                    (int) round($openPlanDesks),
-                )
+            $assets[WorkstationType::OPEN_PLAN_DESKS->value] = new OutputAsset(
+                WorkstationType::OPEN_PLAN_DESKS,
+                (int) round($openPlanDesks),
             );
         }
         if ($openPlanTouchdownSpaces != 0) {
-            $assets->push(
-                new OutputAsset(
-                    WorkstationType::OPEN_PLAN_TOUCHDOWN_DESKS,
-                    (int) round($openPlanTouchdownSpaces),
-                )
+            $assets[WorkstationType::OPEN_PLAN_TOUCHDOWN_DESKS->value] = new OutputAsset(
+                WorkstationType::OPEN_PLAN_TOUCHDOWN_DESKS,
+                (int) round($openPlanTouchdownSpaces),
             );
         }
         $assets = $assets->merge(

--- a/app/Services/SpaceCalculator/Calculator.php
+++ b/app/Services/SpaceCalculator/Calculator.php
@@ -5,6 +5,7 @@ namespace App\Services\SpaceCalculator;
 use App\Enums\Widgets\SpaceCalculator\AreaType;
 use App\Enums\Widgets\SpaceCalculator\Asset;
 use App\Enums\Widgets\SpaceCalculator\CapacityType;
+use App\Enums\Widgets\SpaceCalculator\WorkstationType;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Mattiasgeniar\Percentage\Percentage;
@@ -429,7 +430,6 @@ class Calculator
             (int)$spaciousSquareFootAmount,
             (int)round($spaciousSpaceGrossSmAmount),
         );
-        $assets = collect(); // todo: investigate assets macro - could this be done via map() function?
         $capacityTypes = collect([
             new OutputCapacityType(
                 CapacityType::LONG_DWELL_WORKSTATION,
@@ -493,6 +493,43 @@ class Calculator
                 true,
             ),
         ]);
+
+        $assets = collect();
+
+        if ($privateOffices != 0) {
+            $assets->push(
+                new OutputAsset(
+                    WorkstationType::PRIVATE_OFFICES,
+                    (int) round($privateOffices),
+                )
+            );
+        }
+        if ($openPlanDesks != 0) {
+            $assets->push(
+                new OutputAsset(
+                    WorkstationType::OPEN_PLAN_DESKS,
+                    (int) round($openPlanDesks),
+                )
+            );
+        }
+        if ($openPlanTouchdownSpaces != 0) {
+            $assets->push(
+                new OutputAsset(
+                    WorkstationType::OPEN_PLAN_TOUCHDOWN_DESKS,
+                    (int) round($openPlanTouchdownSpaces),
+                )
+            );
+        }
+        /*$assets = $assets->merge(
+            $assetCalculations->where('quantity', '!=', 0)
+                ->map(function(AssetCalculation $assetCalculation, string $key): OutputAsset {
+                    return new OutputAsset(
+                        Asset::from($key),
+                        $assetCalculation->quantity,
+                    );
+                })
+        );*/
+//dd($assets);
 
         return new Output(
             areaSize: $areaSize,

--- a/app/Services/SpaceCalculator/OutputAsset.php
+++ b/app/Services/SpaceCalculator/OutputAsset.php
@@ -3,15 +3,16 @@
 namespace App\Services\SpaceCalculator;
 
 use App\Enums\Widgets\SpaceCalculator\Asset;
+use App\Enums\Widgets\SpaceCalculator\WorkstationType;
 
 readonly class OutputAsset
 {
     /**
-     * @param Asset $asset
+     * @param Asset|WorkstationType $asset
      * @param int $quantity
      */
     public function __construct(
-        public Asset $asset,
+        public Asset|WorkstationType $asset,
         public int $quantity,
     ) {
         //

--- a/resources/views/web/space-calculator/outputs.blade.php
+++ b/resources/views/web/space-calculator/outputs.blade.php
@@ -12,7 +12,7 @@
 
    <x-space-calculator.outputs.area-types :areaTypes="$outputs->areaTypes" />
 
-   <x-space-calculator.outputs.assets :areaTypes="$outputs->assets" />
+   <x-space-calculator.outputs.assets :assets="$outputs->assets" />
 
    {{-- todo: real text and action in the form --}}
    <form method="post" action="#">


### PR DESCRIPTION
This is for the output of assets which originates from the first sheet of the space calculator spreadsheet. The macro in the spreadsheet is recreated here which does the following steps...

1. Take the amount for "Private Offices"  if it isn't 0 from the workstations sheet and add to the output
2. Take the amount for "Open Plan Desks" if it isn't 0 from the workstations sheet and add to the output
3. Take the amount for "Open Plan Touchdown desks" if it isn't 0 from the workstations sheet and add to the output
4. Take each asset and it's quantity if it isn't 0 and add to the output

So we end up with a collection of `OutputAsset` DTOs which contain up to 3 `WorkstationType` enum elements and up to 47 `Asset` enum elements. 