### PR TITLE
Detailed Output

### DIFF
--- a/app/Http/Controllers/Web/AuthController.php
+++ b/app/Http/Controllers/Web/AuthController.php
@@ -36,6 +36,14 @@ class AuthController extends WebController
     }
 
     /**
+     * @return RedirectResponse
+     */
+    public function postSignIn(): RedirectResponse
+    {
+        dd('This is a placeholder - real content to come in a later card / PR');
+    }
+
+    /**
      * @return View
      */
     public function getSent(): View

--- a/app/Http/Controllers/Web/SpaceCalculator/OutputsController.php
+++ b/app/Http/Controllers/Web/SpaceCalculator/OutputsController.php
@@ -161,6 +161,6 @@ class OutputsController extends WebController
             return redirect(route('web.auth.sent'));
         }
 
-        return redirect('web.portal.index');
+        return redirect(route('web.portal.index'));
     }
 }

--- a/app/Http/Controllers/Web/SpaceCalculator/OutputsController.php
+++ b/app/Http/Controllers/Web/SpaceCalculator/OutputsController.php
@@ -18,7 +18,6 @@ use App\Notifications\SummaryNotification;
 use App\Services\SpaceCalculator\Calculator;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Str;
 use Illuminate\View\View;
 use Propaganistas\LaravelPhone\PhoneNumber;
@@ -151,16 +150,6 @@ class OutputsController extends WebController
 
         $user->notify(new DetailedNotification($spaceCalculatorInput->enquiry));
 
-        if (!Auth::check()) {
-            SendAction::run(
-                $user,
-                $request->ip(),
-                route('web.portal.index', $spaceCalculatorInput)
-            );
-            $request->session()->flash('auth-sent-user', $user);
-            return redirect(route('web.auth.sent'));
-        }
-
-        return redirect(route('web.portal.index'));
+        return redirect(route('web.space-calculator.outputs.detailed.post', $spaceCalculatorInput));
     }
 }

--- a/app/Http/Controllers/Web/SpaceCalculator/OutputsController.php
+++ b/app/Http/Controllers/Web/SpaceCalculator/OutputsController.php
@@ -118,11 +118,18 @@ class OutputsController extends WebController
     }
 
     /**
+     * @param Calculator $calculator
      * @param SpaceCalculatorInput $spaceCalculatorInput
      * @return View
      */
-    public function getDetailed(SpaceCalculatorInput $spaceCalculatorInput): View
+    public function getDetailed(Calculator $calculator, SpaceCalculatorInput $spaceCalculatorInput): View
     {
-        dd('placeholder route - will change');
+        $this->metaTitle('Space Calculator Detailed Results');
+
+        return view('web.space-calculator.detailed-results', [
+            'outputs' => $calculator->calculate($spaceCalculatorInput->transformToCalculatorInputs()),
+            'inputs' => $spaceCalculatorInput,
+            'user' => $spaceCalculatorInput->enquiry->user,
+        ]);
     }
 }

--- a/app/Http/Controllers/Web/SpaceCalculator/OutputsController.php
+++ b/app/Http/Controllers/Web/SpaceCalculator/OutputsController.php
@@ -133,4 +133,10 @@ class OutputsController extends WebController
             'user' => $spaceCalculatorInput->enquiry->user,
         ]);
     }
+
+    public function postDetailed(SpaceCalculatorInput $spaceCalculatorInput): RedirectResponse
+    {
+ // needs request class
+        dd('in post detailed');
+    }
 }

--- a/app/Http/Controllers/Web/SpaceCalculator/OutputsController.php
+++ b/app/Http/Controllers/Web/SpaceCalculator/OutputsController.php
@@ -54,6 +54,7 @@ class OutputsController extends WebController
         $user = User::query()->where('email', $request->input('email'))->first();
 
         if ($user && $user->has_completed_profile) {
+            AttachToUserAction::run($spaceCalculatorInput->enquiry, $user);
             // todo: This intended route is just a placeholder, it will likely change
             SendAction::run(
                 $user,

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -62,8 +62,8 @@ class Kernel extends HttpKernel
         // 'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
 
         'set_tenant' => \App\Http\Middleware\SetTenant::class,
-        'guard_space_calculator_output' =>
-            \App\Http\Middleware\GuardSpaceCalculatorOutput::class,
+        'guard_space_calculator_output' => \App\Http\Middleware\GuardSpaceCalculatorOutput::class,
+        'guard_space_calculator_detailed_output' => \App\Http\Middleware\GuardSpaceCalculatorDetailedOutput::class,
         'verify_magic_link' => \App\Http\Middleware\VerifyMagicLink::class,
     ];
 }

--- a/app/Http/Middleware/GuardSpaceCalculatorDetailedOutput.php
+++ b/app/Http/Middleware/GuardSpaceCalculatorDetailedOutput.php
@@ -27,7 +27,11 @@ class GuardSpaceCalculatorDetailedOutput
         if (!Auth::check()) {
             $user = $model->enquiry->user;
 
-            if ($user && !$user->has_completed_profile) {
+            if (!$user) {
+                return redirect(route('web.space-calculator.index'));
+            }
+
+            if (!$user->has_completed_profile) {
                 return redirect(route('web.space-calculator.index'));
             }
 

--- a/app/Http/Middleware/GuardSpaceCalculatorDetailedOutput.php
+++ b/app/Http/Middleware/GuardSpaceCalculatorDetailedOutput.php
@@ -3,6 +3,7 @@
 namespace App\Http\Middleware;
 
 use App\Models\SpaceCalculatorInput;
+use App\Models\User;
 use Closure;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
@@ -18,23 +19,42 @@ class GuardSpaceCalculatorDetailedOutput
      */
     public function handle(Request $request, Closure $next): Response
     {
-        dd('in detailed output middleware');
-
-        if (Auth::check()) { // todo: change this the prospect portal route when built
-            return redirect(route('web.space-calculator.index'));
-        }
-
-        if (!Session::has(config('widgets.space-calculator.input-session-key'))) {
-            return redirect(route('web.space-calculator.index'));
-        }
-
         /**
          * @var SpaceCalculatorInput $model
          */
         $model = $request->route()?->parameter('spaceCalculatorInput');
 
-        if (Session::get(config('widgets.space-calculator.input-session-key')) !== $model->uuid) {
-            return redirect(route('web.space-calculator.index'));
+        if (!Auth::check()) {
+            $user = $model->enquiry->user;
+
+            if ($user && !$user->has_completed_profile) {
+                return redirect(route('web.space-calculator.index'));
+            }
+
+            if (!Session::has(config('widgets.space-calculator.input-session-key'))) {
+                return redirect(route('web.space-calculator.index'));
+            }
+
+            if (Session::get(config('widgets.space-calculator.input-session-key')) !== $model->uuid) {
+                return redirect(route('web.space-calculator.index'));
+            }
+        }
+
+        if (Auth::check()) {
+
+            /**
+             * @var User $user
+             */
+            $user = Auth::user();
+
+            if (!$user->has_completed_profile) {
+                // todo: discuss - would this link to a profile edit screen perhaps later?
+                return redirect(route('web.portal.index'));
+            }
+
+            if ($model->enquiry->user_id != $user->id) {
+                return redirect(route('web.portal.index'));
+            }
         }
 
         return $next($request);

--- a/app/Http/Middleware/GuardSpaceCalculatorDetailedOutput.php
+++ b/app/Http/Middleware/GuardSpaceCalculatorDetailedOutput.php
@@ -20,26 +20,26 @@ class GuardSpaceCalculatorDetailedOutput
     public function handle(Request $request, Closure $next): Response
     {
         /**
-         * @var SpaceCalculatorInput $model
+         * @var SpaceCalculatorInput $spaceCalculatorInput
          */
-        $model = $request->route()?->parameter('spaceCalculatorInput');
+        $spaceCalculatorInput = $request->route()?->parameter('spaceCalculatorInput');
 
         if (!Auth::check()) {
-            $user = $model->enquiry->user;
+            $user = $spaceCalculatorInput->enquiry->user;
 
             if (!$user) {
-                return redirect(route('web.space-calculator.index'));
+                return redirect(route('web.space-calculator.outputs.index', $spaceCalculatorInput));
             }
 
             if (!$user->has_completed_profile) {
-                return redirect(route('web.space-calculator.index'));
+                return redirect(route('web.space-calculator.outputs.index', $spaceCalculatorInput));
             }
 
             if (!Session::has(config('widgets.space-calculator.input-session-key'))) {
                 return redirect(route('web.space-calculator.index'));
             }
 
-            if (Session::get(config('widgets.space-calculator.input-session-key')) !== $model->uuid) {
+            if (Session::get(config('widgets.space-calculator.input-session-key')) !== $spaceCalculatorInput->uuid) {
                 return redirect(route('web.space-calculator.index'));
             }
         }
@@ -52,11 +52,10 @@ class GuardSpaceCalculatorDetailedOutput
             $user = Auth::user();
 
             if (!$user->has_completed_profile) {
-                // todo: discuss - would this link to a profile edit screen perhaps later?
                 return redirect(route('web.portal.index'));
             }
 
-            if ($model->enquiry->user_id != $user->id) {
+            if (!$spaceCalculatorInput->enquiry->user?->is($user)) {
                 return redirect(route('web.portal.index'));
             }
         }

--- a/app/Http/Middleware/GuardSpaceCalculatorDetailedOutput.php
+++ b/app/Http/Middleware/GuardSpaceCalculatorDetailedOutput.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Session;
 use Symfony\Component\HttpFoundation\Response;
 
-class GuardSpaceCalculatorOutput
+class GuardSpaceCalculatorDetailedOutput
 {
     /**
      * @param Request $request
@@ -18,8 +18,10 @@ class GuardSpaceCalculatorOutput
      */
     public function handle(Request $request, Closure $next): Response
     {
-        if (Auth::check()) {
-            return redirect(route('web.portal.index'));
+        dd('in detailed output middleware');
+
+        if (Auth::check()) { // todo: change this the prospect portal route when built
+            return redirect(route('web.space-calculator.index'));
         }
 
         if (!Session::has(config('widgets.space-calculator.input-session-key'))) {

--- a/app/Notifications/DetailedNotification.php
+++ b/app/Notifications/DetailedNotification.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\Enquiry;
+use App\Models\User;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class DetailedNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    /**
+     * Create a new notification instance.
+     */
+    public function __construct(private readonly Enquiry $enquiry)
+    {
+        //
+    }
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    /**
+     * Get the mail representation of the notification.
+     */
+    public function toMail(User $notifiable): MailMessage
+    {
+        // todo: PDF attachment
+        // todo: email content - this is mostly just a copy of the summary notification for now
+        return (new MailMessage())
+            ->subject('Your space calculator results in more detail')
+            ->greeting('Hi ' . $notifiable->name . ',')
+            ->line('Thank you for using the space calculator with ' . $this->enquiry->tenant->label()
+                . '. Your results are attached to this email.')
+
+            /* todo: the action is a placeholder route, where would it link?
+            (perhaps address this when PDF attached) */
+
+            ->action('Lorem ipsum', route('web.space-calculator.index'));
+
+            // todo: WFG may like to have some marketing text in this email
+    }
+}

--- a/resources/views/web/space-calculator/detailed-results.blade.php
+++ b/resources/views/web/space-calculator/detailed-results.blade.php
@@ -20,8 +20,17 @@
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc sodales, magna sit amet vehicula laoreet, urna nulla mattis turpis, a ultricies neque turpis quis purus. Pellentesque viverra eu nibh sit amet condimentum. Nulla aliquet, nibh id facilisis consectetur, leo elit convallis mi, at consectetur mauris ligula sed metus. In vehicula enim et sem placerat, sit amet scelerisque sapien sagittis. Pellentesque eget aliquet purus. Praesent pretium luctus nibh, ac ullamcorper lacus dignissim pharetra. Nunc nec dictum augue, quis sollicitudin enim. Nulla vitae eros sem. Phasellus eu mauris quis justo interdum molestie vel ut ligula. Vivamus in nisl massa. Suspendisse porttitor efficitur erat, ut cursus metus fermentum eu. Phasellus dictum mauris urna, eget tincidunt ipsum venenatis at. Sed ac nulla sit amet purus ultricies eleifend. Nunc elementum varius metus ut eleifend. Duis lacus metus, convallis sit amet ultricies eu, cursus et sem. Mauris scelerisque, ipsum facilisis tristique imperdiet, metus nibh bibendum mi, nec euismod lectus erat nec ex.</p>
       <x-errors :errors="$errors" />
       @csrf
-      {{-- todo: discuss - by this point they have an email address so no input needed - or should we offer the option for another email address for them? (probably not - so this would literally just be a button) --}}
       <button type="submit" title="Get detailed results PDF">Get detailed results PDF</button>
    </form>
+
+   @guest
+      <form method="post" action="{{ route('web.auth.sign-in.post') }}"> {{-- todo: real wording here --}}
+         <h2>Log in to view your portal</h2>
+         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc sodales, magna sit amet vehicula laoreet, urna nulla mattis turpis, a ultricies neque turpis quis purus. Pellentesque viverra eu nibh sit amet condimentum. Nulla aliquet, nibh id facilisis consectetur, leo elit convallis mi, at consectetur mauris ligula sed metus. In vehicula enim et sem placerat, sit amet scelerisque sapien sagittis. Pellentesque eget aliquet purus. Praesent pretium luctus nibh, ac ullamcorper lacus dignissim pharetra. Nunc nec dictum augue, quis sollicitudin enim. Nulla vitae eros sem. Phasellus eu mauris quis justo interdum molestie vel ut ligula. Vivamus in nisl massa. Suspendisse porttitor efficitur erat, ut cursus metus fermentum eu. Phasellus dictum mauris urna, eget tincidunt ipsum venenatis at. Sed ac nulla sit amet purus ultricies eleifend. Nunc elementum varius metus ut eleifend. Duis lacus metus, convallis sit amet ultricies eu, cursus et sem. Mauris scelerisque, ipsum facilisis tristique imperdiet, metus nibh bibendum mi, nec euismod lectus erat nec ex.</p>
+         <x-errors :errors="$errors" />
+         @csrf
+         <button type="submit" title="Log in to view your portal">Log in to view your portal</button>
+      </form>
+   @endguest
 
 @endsection

--- a/resources/views/web/space-calculator/detailed-results.blade.php
+++ b/resources/views/web/space-calculator/detailed-results.blade.php
@@ -1,0 +1,21 @@
+@extends('skeleton')
+
+@section('page')
+
+   <p>Detailed Results</p> {{-- todo: real content later - this page is a placeholder for now to get the flow working --}}
+
+   <x-space-calculator.outputs.questions :inputs="$inputs" />
+
+   <x-space-calculator.outputs.area-size :areaSize="$outputs->areaSize" />
+
+   <x-space-calculator.outputs.capacity-types :capacityTypes="$outputs->capacityTypes" />
+
+   <x-space-calculator.outputs.area-types :areaTypes="$outputs->areaTypes" />
+
+   <x-space-calculator.outputs.assets :assets="$outputs->assets" />
+
+   {{-- todo: real text and actions in the forms --}}
+
+   {{-- detailed page forms here --}}
+
+@endsection

--- a/resources/views/web/space-calculator/detailed-results.blade.php
+++ b/resources/views/web/space-calculator/detailed-results.blade.php
@@ -15,7 +15,13 @@
    <x-space-calculator.outputs.assets :assets="$outputs->assets" />
 
    {{-- todo: real text and actions in the forms --}}
-
-   {{-- detailed page forms here --}}
+   <form method="post" action="{{ route('web.space-calculator.outputs.detailed.post', $inputs) }}">
+      <h2>Get detailed results PDF</h2>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc sodales, magna sit amet vehicula laoreet, urna nulla mattis turpis, a ultricies neque turpis quis purus. Pellentesque viverra eu nibh sit amet condimentum. Nulla aliquet, nibh id facilisis consectetur, leo elit convallis mi, at consectetur mauris ligula sed metus. In vehicula enim et sem placerat, sit amet scelerisque sapien sagittis. Pellentesque eget aliquet purus. Praesent pretium luctus nibh, ac ullamcorper lacus dignissim pharetra. Nunc nec dictum augue, quis sollicitudin enim. Nulla vitae eros sem. Phasellus eu mauris quis justo interdum molestie vel ut ligula. Vivamus in nisl massa. Suspendisse porttitor efficitur erat, ut cursus metus fermentum eu. Phasellus dictum mauris urna, eget tincidunt ipsum venenatis at. Sed ac nulla sit amet purus ultricies eleifend. Nunc elementum varius metus ut eleifend. Duis lacus metus, convallis sit amet ultricies eu, cursus et sem. Mauris scelerisque, ipsum facilisis tristique imperdiet, metus nibh bibendum mi, nec euismod lectus erat nec ex.</p>
+      <x-errors :errors="$errors" />
+      @csrf
+      {{-- todo: discuss - by this point they have an email address so no input needed - or should we offer the option for another email address for them? (probably not - so this would literally just be a button) --}}
+      <button type="submit" title="Get detailed results PDF">Get detailed results PDF</button>
+   </form>
 
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -40,7 +40,10 @@ Route::group(['prefix' => 'space-calculator'], function (): void {
                 ->name('space-calculator.outputs.profile.post');
         });
 
-        Route::group(['prefix' => 'detailed'], function (): void {
+        Route::group([
+            'prefix' => 'detailed',
+            'middleware' => 'guard_space_calculator_detailed_output'
+        ], function (): void {
 
             Route::get('/', [Web\SpaceCalculator\OutputsController::class, 'getDetailed'])
                 ->name('space-calculator.outputs.detailed');

--- a/routes/web.php
+++ b/routes/web.php
@@ -47,6 +47,9 @@ Route::group(['prefix' => 'space-calculator'], function (): void {
 
             Route::get('/', [Web\SpaceCalculator\OutputsController::class, 'getDetailed'])
                 ->name('space-calculator.outputs.detailed');
+
+            Route::post('/', [Web\SpaceCalculator\OutputsController::class, 'postDetailed'])
+                ->name('space-calculator.outputs.detailed.post');
         });
     });
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -65,6 +65,9 @@ Route::group([
 
     Route::group(['prefix' => 'auth'], function (): void {
 
+        Route::post('sign-in', [Web\AuthController::class, 'postSignIn'])
+            ->name('auth.sign-in.post');
+
         Route::get('sent', [Web\AuthController::class, 'getSent'])
             ->name('auth.sent');
     });

--- a/tests/Feature/Http/Web/SpaceCalculator/OutputsController/GetDetailedTest.php
+++ b/tests/Feature/Http/Web/SpaceCalculator/OutputsController/GetDetailedTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Tests\Feature\Http\Web\SpaceCalculator\OutputsController;
+
+use App\Models\Enquiry;
+use App\Models\SpaceCalculatorInput;
+use App\Models\User;
+use App\Services\SpaceCalculator\Calculator;
+use App\Services\SpaceCalculator\Output;
+use App\Services\SpaceCalculator\OutputAreaSize;
+use Tests\TestCase;
+
+class GetDetailedTest extends TestCase
+{
+    public function test_page_loads_ok_for_guest_after_completing_profile(): void
+    {
+        $user = User::factory()->create(['has_completed_profile' => true]);
+        $enquiry = Enquiry::factory()->create(['user_id' => $user->id]);
+        $inputs = SpaceCalculatorInput::factory()->create(['enquiry_id' => $enquiry->id]);
+
+        $this->mock(Calculator::class)
+            ->shouldReceive("calculate")
+            ->andReturn(new Output(
+                areaSize: new OutputAreaSize(0, 0, 0, 0, 0, 0),
+                assets: collect(),
+                capacityTypes: collect(),
+                areaTypes: collect(),
+            ));
+
+        $this->withSession([config('widgets.space-calculator.input-session-key') => $inputs->uuid])
+            ->get(route('web.space-calculator.outputs.detailed', $inputs->uuid))
+            ->assertOk()
+            ->assertViewIs('web.space-calculator.detailed-results');
+    }
+
+    public function test_page_loads_ok_for_authenticated_user_when_enquiry_is_theirs(): void
+    {
+        $user = User::factory()->create(['has_completed_profile' => true]);
+        $enquiry = Enquiry::factory()->create(['user_id' => $user->id]);
+        $inputs = SpaceCalculatorInput::factory()->create(['enquiry_id' => $enquiry->id]);
+
+        $this->authenticateUser($user);
+
+        $this->mock(Calculator::class)
+            ->shouldReceive("calculate")
+            ->andReturn(new Output(
+                areaSize: new OutputAreaSize(0, 0, 0, 0, 0, 0),
+                assets: collect(),
+                capacityTypes: collect(),
+                areaTypes: collect(),
+            ));
+
+        $this->get(route('web.space-calculator.outputs.detailed', $inputs->uuid))
+            ->assertOk()
+            ->assertViewIs('web.space-calculator.detailed-results');
+    }
+
+    // todo: discuss - is this too over the top for testing? Since auth user's don't have session check in middleware
+    public function test_page_loads_ok_for_authenticated_user_when_enquiry_is_theirs_and_session_is_different_uuid(): void
+    {
+        $user = User::factory()->create(['has_completed_profile' => true]);
+        $enquiry = Enquiry::factory()->create(['user_id' => $user->id]);
+        $inputs = SpaceCalculatorInput::factory()->create(['enquiry_id' => $enquiry->id]);
+
+        $this->authenticateUser($user);
+
+        $this->mock(Calculator::class)
+            ->shouldReceive("calculate")
+            ->andReturn(new Output(
+                areaSize: new OutputAreaSize(0, 0, 0, 0, 0, 0),
+                assets: collect(),
+                capacityTypes: collect(),
+                areaTypes: collect(),
+            ));
+
+        $this->withSession([config('widgets.space-calculator.input-session-key') => $this->faker->uuid])
+            ->get(route('web.space-calculator.outputs.detailed', $inputs->uuid))
+            ->assertOk()
+            ->assertViewIs('web.space-calculator.detailed-results');
+    }
+
+    /*
+     * more to test
+     *
+     * GUEST REDIRECTS
+     * guest user incomplete profile redirect
+     * guest access without user set up yet redirect
+     * guest without session
+     * guess with session different inputs uuid
+     *
+     * AUTH USER REDIRECTS
+     * auth user incomplete profile redirect
+     * auth user can't access if enquiry isn't theirs
+     * auth user can't access if enquiry isn't theirs but has session containing their uuid
+     *
+     */
+}

--- a/tests/Feature/Http/Web/SpaceCalculator/OutputsController/GetDetailedTest.php
+++ b/tests/Feature/Http/Web/SpaceCalculator/OutputsController/GetDetailedTest.php
@@ -30,6 +30,7 @@ class GetDetailedTest extends TestCase
         $this->withSession([config('widgets.space-calculator.input-session-key') => $inputs->uuid])
             ->get(route('web.space-calculator.outputs.detailed', $inputs->uuid))
             ->assertOk()
+            ->assertSeeText('Log in to view your portal')
             ->assertViewIs('web.space-calculator.detailed-results');
     }
 
@@ -52,6 +53,7 @@ class GetDetailedTest extends TestCase
 
         $this->get(route('web.space-calculator.outputs.detailed', $inputs->uuid))
             ->assertOk()
+            ->assertDontSeeText('Log in to view your portal')
             ->assertViewIs('web.space-calculator.detailed-results');
     }
 
@@ -76,6 +78,7 @@ class GetDetailedTest extends TestCase
         $this->withSession([config('widgets.space-calculator.input-session-key') => $this->faker->uuid])
             ->get(route('web.space-calculator.outputs.detailed', $inputs->uuid))
             ->assertOk()
+            ->assertDontSeeText('Log in to view your portal')
             ->assertViewIs('web.space-calculator.detailed-results');
     }
 

--- a/tests/Feature/Http/Web/SpaceCalculator/OutputsController/GetDetailedTest.php
+++ b/tests/Feature/Http/Web/SpaceCalculator/OutputsController/GetDetailedTest.php
@@ -57,31 +57,6 @@ class GetDetailedTest extends TestCase
             ->assertViewIs('web.space-calculator.detailed-results');
     }
 
-    // todo: discuss - is this too over the top for testing? Since auth user's don't have session check in middleware
-    public function test_page_loads_ok_for_authenticated_user_when_enquiry_is_theirs_and_session_is_different_uuid(): void
-    {
-        $user = User::factory()->create(['has_completed_profile' => true]);
-        $enquiry = Enquiry::factory()->create(['user_id' => $user->id]);
-        $inputs = SpaceCalculatorInput::factory()->create(['enquiry_id' => $enquiry->id]);
-
-        $this->authenticateUser($user);
-
-        $this->mock(Calculator::class)
-            ->shouldReceive("calculate")
-            ->andReturn(new Output(
-                areaSize: new OutputAreaSize(0, 0, 0, 0, 0, 0),
-                assets: collect(),
-                capacityTypes: collect(),
-                areaTypes: collect(),
-            ));
-
-        $this->withSession([config('widgets.space-calculator.input-session-key') => $this->faker->uuid])
-            ->get(route('web.space-calculator.outputs.detailed', $inputs->uuid))
-            ->assertOk()
-            ->assertDontSeeText('Log in to view your portal')
-            ->assertViewIs('web.space-calculator.detailed-results');
-    }
-
     public function test_redirect_for_guest_with_incomplete_profile(): void
     {
         $user = User::factory()->create(['has_completed_profile' => false]);
@@ -93,7 +68,7 @@ class GetDetailedTest extends TestCase
 
         $this->withSession([config('widgets.space-calculator.input-session-key') => $inputs->uuid])
             ->get(route('web.space-calculator.outputs.detailed', $inputs->uuid))
-            ->assertRedirect(route('web.space-calculator.index'));
+            ->assertRedirect(route('web.space-calculator.outputs.index', $inputs));
     }
 
     public function test_redirect_for_guest_before_user_set_up(): void
@@ -105,7 +80,7 @@ class GetDetailedTest extends TestCase
 
         $this->withSession([config('widgets.space-calculator.input-session-key') => $inputs->uuid])
             ->get(route('web.space-calculator.outputs.detailed', $inputs->uuid))
-            ->assertRedirect(route('web.space-calculator.index'));
+            ->assertRedirect(route('web.space-calculator.outputs.index', $inputs));
     }
 
     public function test_redirect_for_guest_without_session(): void
@@ -163,23 +138,6 @@ class GetDetailedTest extends TestCase
             ->shouldNotHaveBeenCalled();
 
         $this->get(route('web.space-calculator.outputs.detailed', $inputs->uuid))
-            ->assertRedirect(route('web.portal.index'));
-    }
-
-    // todo: discuss - this one possibly over the top or worth testing?
-    public function test_redirect_for_authenticated_user_if_enquiry_is_not_theirs_even_though_the_inputs_uuid_is_in_the_session(): void
-    {
-        $user = User::factory()->create(['has_completed_profile' => true]);
-        $enquiry = Enquiry::factory()->create(['user_id' => User::factory()->make()->id]);
-        $inputs = SpaceCalculatorInput::factory()->create(['enquiry_id' => $enquiry->id]);
-
-        $this->authenticateUser($user);
-
-        $this->mock(Calculator::class)
-            ->shouldNotHaveBeenCalled();
-
-        $this->withSession([config('widgets.space-calculator.input-session-key') => $inputs->uuid])
-            ->get(route('web.space-calculator.outputs.detailed', $inputs->uuid))
             ->assertRedirect(route('web.portal.index'));
     }
 }

--- a/tests/Feature/Http/Web/SpaceCalculator/OutputsController/GetIndexTest.php
+++ b/tests/Feature/Http/Web/SpaceCalculator/OutputsController/GetIndexTest.php
@@ -66,7 +66,7 @@ class GetIndexTest extends TestCase
 
         $this->withSession([config('widgets.space-calculator.input-session-key') => $inputs->uuid])
             ->get(route('web.space-calculator.outputs.index', $inputs->uuid))
-            ->assertRedirect(route('web.space-calculator.index'));
+            ->assertRedirect(route('web.portal.index'));
     }
 
     public function test_without_session_redirects_away(): void
@@ -82,8 +82,6 @@ class GetIndexTest extends TestCase
     public function test_try_to_access_results_for_inputs_when_different_uuid_is_in_session(): void
     {
         $this->mock(Calculator::class);
-
-        $this->authenticateUser();
 
         $inputs_1 = SpaceCalculatorInput::factory()->create();
         $inputs_2 = SpaceCalculatorInput::factory()->create();

--- a/tests/Feature/Http/Web/SpaceCalculator/OutputsController/PostDetailedTest.php
+++ b/tests/Feature/Http/Web/SpaceCalculator/OutputsController/PostDetailedTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Feature\Http\Web\SpaceCalculator\OutputsController;
 
-use App\Actions\MagicLinks\SendAction;
 use App\Models\Enquiry;
 use App\Models\SpaceCalculatorInput;
 use App\Models\User;
@@ -20,17 +19,9 @@ class PostDetailedTest extends TestCase
         $enquiry = Enquiry::factory()->create(['user_id' => $user->id]);
         $inputs = SpaceCalculatorInput::factory()->create(['enquiry_id' => $enquiry->id]);
 
-        SendAction::shouldRun()
-            ->once()
-            ->with(
-                $this->mockArgModel($user),
-                '127.0.0.1',
-                route('web.portal.index', $inputs),
-            );
-
         $this->withSession([config('widgets.space-calculator.input-session-key') => $inputs->uuid])
             ->post(route('web.space-calculator.outputs.detailed.post', $inputs))
-            ->assertRedirect(route('web.auth.sent'))
+            ->assertRedirect(route('web.space-calculator.outputs.detailed.post', $inputs))
             ->assertSessionHasNoErrors();
 
         Notification::assertCount(1);
@@ -49,13 +40,9 @@ class PostDetailedTest extends TestCase
         $enquiry = Enquiry::factory()->create(['user_id' => $user->id]);
         $inputs = SpaceCalculatorInput::factory()->create(['enquiry_id' => $enquiry->id]);
 
-        $this->authenticateUser($user);
-
-        SendAction::shouldNotRun();
-
         $this->withSession([config('widgets.space-calculator.input-session-key') => $inputs->uuid])
             ->post(route('web.space-calculator.outputs.detailed.post', $inputs))
-            ->assertRedirect(route('web.portal.index'))
+            ->assertRedirect(route('web.space-calculator.outputs.detailed.post', $inputs))
             ->assertSessionHasNoErrors();
 
         Notification::assertCount(1);
@@ -74,11 +61,9 @@ class PostDetailedTest extends TestCase
         $enquiry = Enquiry::factory()->create(['user_id' => $user->id]);
         $inputs = SpaceCalculatorInput::factory()->create(['enquiry_id' => $enquiry->id]);
 
-        SendAction::shouldNotRun();
-
         $this->withSession([config('widgets.space-calculator.input-session-key') => $inputs->uuid])
             ->post(route('web.space-calculator.outputs.detailed.post', $inputs))
-            ->assertRedirect(route('web.space-calculator.index'))
+            ->assertRedirect(route('web.space-calculator.outputs.index', $inputs))
             ->assertSessionHasNoErrors();
 
         Notification::assertCount(0);
@@ -90,11 +75,9 @@ class PostDetailedTest extends TestCase
 
         $inputs = SpaceCalculatorInput::factory()->create();
 
-        SendAction::shouldNotRun();
-
         $this->withSession([config('widgets.space-calculator.input-session-key') => $inputs->uuid])
             ->post(route('web.space-calculator.outputs.detailed.post', $inputs))
-            ->assertRedirect(route('web.space-calculator.index'))
+            ->assertRedirect(route('web.space-calculator.outputs.index', $inputs))
             ->assertSessionHasNoErrors();
 
         Notification::assertCount(0);
@@ -107,8 +90,6 @@ class PostDetailedTest extends TestCase
         $user = User::factory()->create(['has_completed_profile' => true]);
         $enquiry = Enquiry::factory()->create(['user_id' => $user->id]);
         $inputs = SpaceCalculatorInput::factory()->create(['enquiry_id' => $enquiry->id]);
-
-        SendAction::shouldNotRun();
 
         $this->post(route('web.space-calculator.outputs.detailed.post', $inputs))
             ->assertRedirect(route('web.space-calculator.index'))
@@ -124,8 +105,6 @@ class PostDetailedTest extends TestCase
         $user = User::factory()->create(['has_completed_profile' => true]);
         $enquiry = Enquiry::factory()->create(['user_id' => $user->id]);
         $inputs = SpaceCalculatorInput::factory()->create(['enquiry_id' => $enquiry->id]);
-
-        SendAction::shouldNotRun();
 
         $this->withSession([config('widgets.space-calculator.input-session-key') => $this->faker->uuid])
             ->post(route('web.space-calculator.outputs.detailed.post', $inputs))
@@ -164,24 +143,6 @@ class PostDetailedTest extends TestCase
         $this->authenticateUser($user);
 
         $this->post(route('web.space-calculator.outputs.detailed.post', $inputs))
-            ->assertRedirect(route('web.portal.index'))
-            ->assertSessionHasNoErrors();
-
-        Notification::assertCount(0);
-    }
-
-    public function test_redirect_for_authenticated_user_if_enquiry_is_not_theirs_even_though_the_inputs_uuid_is_in_the_session(): void
-    {
-        Notification::fake();
-
-        $user = User::factory()->create(['has_completed_profile' => true]);
-        $enquiry = Enquiry::factory()->create(['user_id' => User::factory()->make()->id]);
-        $inputs = SpaceCalculatorInput::factory()->create(['enquiry_id' => $enquiry->id]);
-
-        $this->authenticateUser($user);
-
-        $this->withSession([config('widgets.space-calculator.input-session-key') => $inputs->uuid])
-            ->post(route('web.space-calculator.outputs.detailed.post', $inputs))
             ->assertRedirect(route('web.portal.index'))
             ->assertSessionHasNoErrors();
 

--- a/tests/Feature/Http/Web/SpaceCalculator/OutputsController/PostDetailedTest.php
+++ b/tests/Feature/Http/Web/SpaceCalculator/OutputsController/PostDetailedTest.php
@@ -1,0 +1,190 @@
+<?php
+
+namespace Tests\Feature\Http\Web\SpaceCalculator\OutputsController;
+
+use App\Actions\MagicLinks\SendAction;
+use App\Models\Enquiry;
+use App\Models\SpaceCalculatorInput;
+use App\Models\User;
+use App\Notifications\DetailedNotification;
+use Illuminate\Support\Facades\Notification;
+use Tests\TestCase;
+
+class PostDetailedTest extends TestCase
+{
+    public function test_posts_ok_for_guest(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->create(['has_completed_profile' => true]);
+        $enquiry = Enquiry::factory()->create(['user_id' => $user->id]);
+        $inputs = SpaceCalculatorInput::factory()->create(['enquiry_id' => $enquiry->id]);
+
+        SendAction::shouldRun()
+            ->once()
+            ->with(
+              $this->mockArgModel($user),
+              '127.0.0.1',
+                route('web.portal.index', $inputs),
+            );
+
+        $this->withSession([config('widgets.space-calculator.input-session-key') => $inputs->uuid])
+            ->post(route('web.space-calculator.outputs.detailed.post', $inputs))
+            ->assertRedirect(route('web.auth.sent'))
+            ->assertSessionHasNoErrors();
+
+        Notification::assertCount(1);
+
+        Notification::assertSentTo(
+            $user,
+            DetailedNotification::class,
+        );
+    }
+
+    public function test_posts_ok_for_authenticated_user(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->create(['has_completed_profile' => true]);
+        $enquiry = Enquiry::factory()->create(['user_id' => $user->id]);
+        $inputs = SpaceCalculatorInput::factory()->create(['enquiry_id' => $enquiry->id]);
+
+        $this->authenticateUser($user);
+
+        SendAction::shouldNotRun();
+
+        $this->withSession([config('widgets.space-calculator.input-session-key') => $inputs->uuid])
+            ->post(route('web.space-calculator.outputs.detailed.post', $inputs))
+            ->assertRedirect(route('web.portal.index'))
+            ->assertSessionHasNoErrors();
+
+        Notification::assertCount(1);
+
+        Notification::assertSentTo(
+            $user,
+            DetailedNotification::class,
+        );
+    }
+
+    public function test_redirect_for_guest_with_incomplete_profile(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->create(['has_completed_profile' => false]);
+        $enquiry = Enquiry::factory()->create(['user_id' => $user->id]);
+        $inputs = SpaceCalculatorInput::factory()->create(['enquiry_id' => $enquiry->id]);
+
+        SendAction::shouldNotRun();
+
+        $this->withSession([config('widgets.space-calculator.input-session-key') => $inputs->uuid])
+            ->post(route('web.space-calculator.outputs.detailed.post', $inputs))
+            ->assertRedirect(route('web.space-calculator.index'))
+            ->assertSessionHasNoErrors();
+
+        Notification::assertCount(0);
+    }
+
+    public function test_redirect_for_guest_before_user_set_up(): void
+    {
+        Notification::fake();
+
+        $inputs = SpaceCalculatorInput::factory()->create();
+
+        SendAction::shouldNotRun();
+
+        $this->withSession([config('widgets.space-calculator.input-session-key') => $inputs->uuid])
+            ->post(route('web.space-calculator.outputs.detailed.post', $inputs))
+            ->assertRedirect(route('web.space-calculator.index'))
+            ->assertSessionHasNoErrors();
+
+        Notification::assertCount(0);
+    }
+
+    public function test_redirect_for_guest_without_session(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->create(['has_completed_profile' => true]);
+        $enquiry = Enquiry::factory()->create(['user_id' => $user->id]);
+        $inputs = SpaceCalculatorInput::factory()->create(['enquiry_id' => $enquiry->id]);
+
+        SendAction::shouldNotRun();
+
+        $this->post(route('web.space-calculator.outputs.detailed.post', $inputs))
+            ->assertRedirect(route('web.space-calculator.index'))
+            ->assertSessionHasNoErrors();
+
+        Notification::assertCount(0);
+    }
+
+    public function test_redirect_for_guest_with_different_uuid_in_session(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->create(['has_completed_profile' => true]);
+        $enquiry = Enquiry::factory()->create(['user_id' => $user->id]);
+        $inputs = SpaceCalculatorInput::factory()->create(['enquiry_id' => $enquiry->id]);
+
+        SendAction::shouldNotRun();
+
+        $this->withSession([config('widgets.space-calculator.input-session-key') => $this->faker->uuid])
+            ->post(route('web.space-calculator.outputs.detailed.post', $inputs))
+            ->assertRedirect(route('web.space-calculator.index'))
+            ->assertSessionHasNoErrors();
+
+        Notification::assertCount(0);
+    }
+
+    public function test_redirect_for_authenticated_user_with_incomplete_profile(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->create(['has_completed_profile' => false]);
+        $enquiry = Enquiry::factory()->create(['user_id' => $user->id]);
+        $inputs = SpaceCalculatorInput::factory()->create(['enquiry_id' => $enquiry->id]);
+
+        $this->authenticateUser($user);
+
+        $this->withSession([config('widgets.space-calculator.input-session-key') => $inputs->uuid])
+            ->post(route('web.space-calculator.outputs.detailed.post', $inputs))
+            ->assertRedirect(route('web.portal.index'))
+            ->assertSessionHasNoErrors();
+
+        Notification::assertCount(0);
+    }
+
+    public function test_redirect_for_authenticated_user_if_enquiry_is_not_theirs(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->create(['has_completed_profile' => true]);
+        $enquiry = Enquiry::factory()->create(['user_id' => User::factory()->make()->id]);
+        $inputs = SpaceCalculatorInput::factory()->create(['enquiry_id' => $enquiry->id]);
+
+        $this->authenticateUser($user);
+
+        $this->post(route('web.space-calculator.outputs.detailed.post', $inputs))
+            ->assertRedirect(route('web.portal.index'))
+            ->assertSessionHasNoErrors();
+
+        Notification::assertCount(0);
+    }
+
+    public function test_redirect_for_authenticated_user_if_enquiry_is_not_theirs_even_though_the_inputs_uuid_is_in_the_session(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->create(['has_completed_profile' => true]);
+        $enquiry = Enquiry::factory()->create(['user_id' => User::factory()->make()->id]);
+        $inputs = SpaceCalculatorInput::factory()->create(['enquiry_id' => $enquiry->id]);
+
+        $this->authenticateUser($user);
+
+        $this->withSession([config('widgets.space-calculator.input-session-key') => $inputs->uuid])
+            ->post(route('web.space-calculator.outputs.detailed.post', $inputs))
+            ->assertRedirect(route('web.portal.index'))
+            ->assertSessionHasNoErrors();
+
+        Notification::assertCount(0);
+    }
+}

--- a/tests/Feature/Http/Web/SpaceCalculator/OutputsController/PostDetailedTest.php
+++ b/tests/Feature/Http/Web/SpaceCalculator/OutputsController/PostDetailedTest.php
@@ -23,8 +23,8 @@ class PostDetailedTest extends TestCase
         SendAction::shouldRun()
             ->once()
             ->with(
-              $this->mockArgModel($user),
-              '127.0.0.1',
+                $this->mockArgModel($user),
+                '127.0.0.1',
                 route('web.portal.index', $inputs),
             );
 

--- a/tests/Feature/Http/Web/SpaceCalculator/OutputsController/PostIndexTest.php
+++ b/tests/Feature/Http/Web/SpaceCalculator/OutputsController/PostIndexTest.php
@@ -27,8 +27,14 @@ class PostIndexTest extends TestCase
                 route('web.space-calculator.outputs.detailed', $inputs),
             );
 
+        AttachToUserAction::shouldRun()
+            ->once()
+            ->with(
+                $this->mockArgModel($inputs->enquiry),
+                $this->mockArgModel($user),
+            );
+
         CreateAction::shouldNotRun();
-        AttachToUserAction::shouldNotRun();
 
         $this->withSession([config('widgets.space-calculator.input-session-key') => $inputs->uuid])
             ->post(route('web.space-calculator.outputs.index.post', $inputs), [

--- a/tests/Feature/Http/Web/SpaceCalculator/OutputsController/PostIndexTest.php
+++ b/tests/Feature/Http/Web/SpaceCalculator/OutputsController/PostIndexTest.php
@@ -144,7 +144,7 @@ class PostIndexTest extends TestCase
             ->post(route('web.space-calculator.outputs.index.post', $inputs), [
                 'email' => $this->faker->email,
             ])
-            ->assertRedirect(route('web.space-calculator.index'));
+            ->assertRedirect(route('web.portal.index'));
 
         Notification::assertCount(0);
     }
@@ -170,8 +170,6 @@ class PostIndexTest extends TestCase
     public function test_try_to_access_results_for_inputs_when_different_uuid_is_in_session(): void
     {
         Notification::fake();
-
-        $this->authenticateUser();
 
         $inputs = SpaceCalculatorInput::factory()->create();
 


### PR DESCRIPTION
This is for the get and post routes of the detailed output. The detailed output page can be accessed by guests who have completed their profile AND have the correct session set up as well as the authenticated user to whom the related enquiry belongs to. There is a form for both types of users to get the notification sent to them. There is a form for guests only which links them to log in to the system - this is just a placeholder route for now to come in a future PR.

There is a middleware for the route that controls access. Tests have been set up for the two routes.

There is also a change to logic built previously where if an authenticated user followed the "not been here before" flow then the enquiry was not getting attached to them. They would have been sent the email and then not able to access the detailed view, so this has been amended and the test for it has been updated.

There are questions in the comments as normal.