### PR TITLE
Generic magic link request form

### DIFF
--- a/app/Http/Controllers/Web/AuthController.php
+++ b/app/Http/Controllers/Web/AuthController.php
@@ -3,8 +3,11 @@
 namespace App\Http\Controllers\Web;
 
 use App\Actions\MagicLinks\MarkAsAuthenticated;
+use App\Actions\MagicLinks\SendAction;
 use App\Http\Controllers\WebController;
+use App\Http\Requests\Web\Auth\PostSignInRequest;
 use App\Models\MagicLink;
+use App\Models\User;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
@@ -46,11 +49,21 @@ class AuthController extends WebController
     }
 
     /**
+     * @param PostSignInRequest $request
      * @return RedirectResponse
      */
-    public function postSignIn(): RedirectResponse
+    public function postSignIn(PostSignInRequest $request): RedirectResponse
     {
-        dd('This is a placeholder - real content to come in a later card / PR');
+        /**
+         * @var User $user
+         */
+        $user = User::query()->where('email', $request->input('email'))->first();
+
+        SendAction::run($user, $request->ip(), route('web.portal.index'));
+
+        $request->session()->flash('auth-sent-user', $user);
+
+        return redirect(route('web.auth.sent'));
     }
 
     /**

--- a/app/Http/Controllers/Web/AuthController.php
+++ b/app/Http/Controllers/Web/AuthController.php
@@ -36,6 +36,16 @@ class AuthController extends WebController
     }
 
     /**
+     * @return View
+     */
+    public function getSignIn(): View
+    {
+        $this->metaTitle('Sign in');
+
+        return view('web.auth.sign-in');
+    }
+
+    /**
      * @return RedirectResponse
      */
     public function postSignIn(): RedirectResponse

--- a/app/Http/Requests/Web/Auth/PostSignInRequest.php
+++ b/app/Http/Requests/Web/Auth/PostSignInRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests\Web\Auth;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rules\Enum;
+
+class PostSignInRequest extends FormRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, array<int, string|Enum>>
+     */
+    public function rules(): array
+    {
+        return [
+            'email' => ['required', 'email', 'exists:users,email'],
+        ];
+    }
+}

--- a/resources/views/web/auth/sign-in.blade.php
+++ b/resources/views/web/auth/sign-in.blade.php
@@ -1,0 +1,18 @@
+@extends('skeleton')
+
+@section('page')
+    {{-- todo: real content here - doesn't have to be much? --}}
+    <h1>Sign In</h1>
+
+    <p>Lorem ipsum dolor sit amet</p>
+
+    <form method="post" action="{{ route('web.auth.sign-in.post') }}">
+        @csrf
+        <x-forms.label for="email">Email address</x-forms.label>
+        <x-forms.text type="email" id="email" name="email" :value="old('email')" />
+        <button type="submit" title="Sign In">Sign In</button>
+    </form>
+
+    <a href="{{ route('web.home.index') }}" title="Back to portal">Back to portal</a>
+
+@endsection

--- a/resources/views/web/auth/sign-in.blade.php
+++ b/resources/views/web/auth/sign-in.blade.php
@@ -6,8 +6,9 @@
 
     <p>Lorem ipsum dolor sit amet</p>
 
-    <form method="post" action="{{ route('web.auth.sign-in.post') }}">
+    <form method="post" action="{{ route('web.auth.sign-in.post') }}" novalidate>
         @csrf
+        <x-errors :errors="$errors" />
         <x-forms.label for="email">Email address</x-forms.label>
         <x-forms.text type="email" id="email" name="email" :value="old('email')" />
         <button type="submit" title="Sign In">Sign In</button>

--- a/resources/views/web/auth/sign-in.blade.php
+++ b/resources/views/web/auth/sign-in.blade.php
@@ -4,14 +4,14 @@
     {{-- todo: real content here - doesn't have to be much? --}}
     <h1>Sign In</h1>
 
-    <p>Lorem ipsum dolor sit amet</p>
+    <p>Enter your email address below, and we'll send you a link to access your portal.</p>
 
     <form method="post" action="{{ route('web.auth.sign-in.post') }}" novalidate>
         @csrf
         <x-errors :errors="$errors" />
         <x-forms.label for="email">Email address</x-forms.label>
         <x-forms.text type="email" id="email" name="email" :value="old('email')" />
-        <button type="submit" title="Sign In">Sign In</button>
+        <button type="submit" title="Get my sign in link">Get my sign in link</button>
     </form>
 
     <a href="{{ route('web.home.index') }}" title="Back to portal">Back to portal</a>

--- a/resources/views/web/auth/sign-in.blade.php
+++ b/resources/views/web/auth/sign-in.blade.php
@@ -14,6 +14,6 @@
         <button type="submit" title="Get my sign in link">Get my sign in link</button>
     </form>
 
-    <a href="{{ route('web.home.index') }}" title="Back to portal">Back to portal</a>
+    <a href="{{ route('web.home.index') }}" title="Back to homepage">Back to homepage</a>
 
 @endsection

--- a/resources/views/web/auth/sign-out.blade.php
+++ b/resources/views/web/auth/sign-out.blade.php
@@ -2,13 +2,13 @@
 
 @section('page')
     {{-- todo: real content here - doesn't have to be much? --}}
-    <h1>Are you sure you want to logout?</h1>
+    <h1>Are you sure you want to sign out?</h1>
 
     <p>Lorem ipsum dolor sit amet</p>
 
     <form method="post" action="{{ route('web.sign-out.post') }}">
         @csrf
-        <button type="submit" title="Logout">Logout</button>
+        <button type="submit" title="Sign Out">Sign Out</button>
     </form>
 
     <a href="{{ route('web.home.index') }}" title="Back to portal">Back to portal</a>

--- a/resources/views/web/space-calculator/landing.blade.php
+++ b/resources/views/web/space-calculator/landing.blade.php
@@ -10,7 +10,7 @@
     {{-- wording and placement of these buttons TBC --}}
     <div>
         <div>
-            <a href="#" title="Returning User">
+            <a href="{{ route('web.auth.sign-in') }}" title="Returning User">
                 Returning User
             </a>
         </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -65,6 +65,9 @@ Route::group([
 
     Route::group(['prefix' => 'auth'], function (): void {
 
+        Route::get('/sign-in', [Web\AuthController::class, 'getSignIn'])
+            ->name('auth.sign-in');
+
         Route::post('sign-in', [Web\AuthController::class, 'postSignIn'])
             ->name('auth.sign-in.post');
 

--- a/tests/Feature/Http/Web/AuthController/GetSignInTest.php
+++ b/tests/Feature/Http/Web/AuthController/GetSignInTest.php
@@ -16,7 +16,7 @@ class GetSignInTest extends TestCase
                 'Sign In',
                 'Email address',
                 'Get my sign in link',
-                'Back to portal'
+                'Back to homepage'
             ]);
     }
 

--- a/tests/Feature/Http/Web/AuthController/GetSignInTest.php
+++ b/tests/Feature/Http/Web/AuthController/GetSignInTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tests\Feature\Http\Web\AuthController;
+
+use App\Models\User;
+use Tests\TestCase;
+
+class GetSignInTest extends TestCase
+{
+    public function test_can_access_route_as_guest(): void
+    {
+        $this->get(route('web.auth.sign-in'))
+            ->assertOk()
+            ->assertViewIs('web.auth.sign-in')
+            ->assertSeeTextInOrder([
+                'Sign In',
+                'Email address',
+                'Sign In',
+                'Back to portal'
+            ]);
+    }
+
+    public function test_cannot_access_route_as_auth_user(): void
+    {
+        $user = User::factory()->create();
+
+        $this->authenticateUser($user);
+
+        $this->get(route('web.auth.sign-in'))
+            ->assertRedirect(route('web.home.index'));
+    }
+}

--- a/tests/Feature/Http/Web/AuthController/GetSignInTest.php
+++ b/tests/Feature/Http/Web/AuthController/GetSignInTest.php
@@ -15,7 +15,7 @@ class GetSignInTest extends TestCase
             ->assertSeeTextInOrder([
                 'Sign In',
                 'Email address',
-                'Sign In',
+                'Get my sign in link',
                 'Back to portal'
             ]);
     }

--- a/tests/Feature/Http/Web/AuthController/PostSignInTest.php
+++ b/tests/Feature/Http/Web/AuthController/PostSignInTest.php
@@ -26,7 +26,7 @@ class PostSignInTest extends TestCase
            'email' => $user->email,
         ])
             ->assertRedirect(route('web.auth.sent'))
-            ->assertSessionHas('auth-sent-user'); // todo: discuss - asserting session = $user fails here?
+            ->assertSessionHas('auth-sent-user.id', $user->id);
     }
 
     public function test_cannot_post_as_authenticated_user(): void
@@ -41,7 +41,7 @@ class PostSignInTest extends TestCase
         $this->post(route('web.auth.sign-in.post'), [
             'email' => $user_2->email,
         ])
-            ->assertRedirect(route('web.home.index'))
+            ->assertRedirect()
             ->assertSessionMissing('auth-sent-user');
     }
 
@@ -56,8 +56,11 @@ class PostSignInTest extends TestCase
         $this->post(route('web.auth.sign-in.post'), [
             //
         ])
-            ->assertRedirect(route('web.home.index'))
-            ->assertSessionMissing('auth-sent-user');
+            ->assertRedirect()
+            ->assertSessionMissing('auth-sent-user')
+            ->assertSessionHasErrors([
+                'email' => 'The email field is required.'
+            ]);
     }
 
     public function test_email_must_be_valid(): void
@@ -71,8 +74,11 @@ class PostSignInTest extends TestCase
         $this->post(route('web.auth.sign-in.post'), [
             'email' => 'loremIpsum123'
         ])
-            ->assertRedirect(route('web.home.index'))
-            ->assertSessionMissing('auth-sent-user');
+            ->assertRedirect()
+            ->assertSessionMissing('auth-sent-user')
+            ->assertSessionHasErrors([
+                'email' => 'The email field must be a valid email address.'
+            ]);
     }
 
     public function test_email_must_belong_to_existing_user(): void
@@ -88,7 +94,10 @@ class PostSignInTest extends TestCase
         $this->post(route('web.auth.sign-in.post'), [
             'email' => 'damon@blur.co.uk'
         ])
-            ->assertRedirect(route('web.home.index'))
-            ->assertSessionMissing('auth-sent-user');
+            ->assertRedirect()
+            ->assertSessionMissing('auth-sent-user')
+            ->assertSessionHasErrors([
+                'email' => 'The selected email is invalid.'
+            ]);
     }
 }

--- a/tests/Feature/Http/Web/AuthController/PostSignInTest.php
+++ b/tests/Feature/Http/Web/AuthController/PostSignInTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Tests\Feature\Http\Web\AuthController;
+
+use App\Actions\MagicLinks\SendAction;
+use App\Models\User;
+use Tests\TestCase;
+
+class PostSignInTest extends TestCase
+{
+    public function test_can_post_as_guest(): void
+    {
+        $user = User::factory()->create();
+
+        $this->assertGuest();
+
+        SendAction::shouldRun()
+            ->once()
+            ->with(
+                $this->mockArgModel($user),
+                '127.0.0.1',
+                route('web.portal.index'),
+            );
+
+        $this->post(route('web.auth.sign-in.post'), [
+           'email' => $user->email,
+        ])
+            ->assertRedirect(route('web.auth.sent'))
+            ->assertSessionHas('auth-sent-user'); // todo: discuss - asserting session = $user fails here?
+    }
+
+    public function test_cannot_post_as_authenticated_user(): void
+    {
+        $user_1 = User::factory()->create();
+        $user_2 = User::factory()->create();
+
+        $this->authenticateUser($user_1);
+
+        SendAction::shouldNotRun();
+
+        $this->post(route('web.auth.sign-in.post'), [
+            'email' => $user_2->email,
+        ])
+            ->assertRedirect(route('web.home.index'))
+            ->assertSessionMissing('auth-sent-user');
+    }
+
+    public function test_required_field(): void
+    {
+        User::factory()->create();
+
+        $this->assertGuest();
+
+        SendAction::shouldNotRun();
+
+        $this->post(route('web.auth.sign-in.post'), [
+            //
+        ])
+            ->assertRedirect(route('web.home.index'))
+            ->assertSessionMissing('auth-sent-user');
+    }
+
+    public function test_email_must_be_valid(): void
+    {
+        User::factory()->create();
+
+        $this->assertGuest();
+
+        SendAction::shouldNotRun();
+
+        $this->post(route('web.auth.sign-in.post'), [
+            'email' => 'loremIpsum123'
+        ])
+            ->assertRedirect(route('web.home.index'))
+            ->assertSessionMissing('auth-sent-user');
+    }
+
+    public function test_email_must_belong_to_existing_user(): void
+    {
+        User::factory()->create(['email' => 'liam@oasis.co.uk']);
+        User::factory()->create(['email' => 'noel@oasis.co.uk']);
+        User::factory()->create(['email' => 'andy@oasis.co.uk']);
+
+        $this->assertGuest();
+
+        SendAction::shouldNotRun();
+
+        $this->post(route('web.auth.sign-in.post'), [
+            'email' => 'damon@blur.co.uk'
+        ])
+            ->assertRedirect(route('web.home.index'))
+            ->assertSessionMissing('auth-sent-user');
+    }
+}


### PR DESCRIPTION
When you click the "returning user" link on the space calculator page it now goes to a sign in page. It's generic so it can be reused for other calculators in the future. You just fill in your email address and you get sent a magic link via the existing action. 

There is just one question in the tests about asserting a session.