### PR TITLE
Error Pages UI

### DIFF
--- a/resources/views/errors/401.blade.php
+++ b/resources/views/errors/401.blade.php
@@ -1,0 +1,8 @@
+@extends('errors::layout')
+
+@section('title', __('Unauthorized'))
+@section('code', '401')
+@section('message', __('You must be signed in to access the page you requested.'))
+@section('actions')
+    <a href="/{{-- route('web.auth.sign-in') --}}" title="Sign In">Sign In</a>
+@endsection {{-- todo: change route when generic magic link PR is merged in --}}

--- a/resources/views/errors/402.blade.php
+++ b/resources/views/errors/402.blade.php
@@ -1,0 +1,5 @@
+@extends('errors::layout')
+
+@section('title', __('Payment Required'))
+@section('code', '402')
+@section('message', __('Payment Required'))

--- a/resources/views/errors/402.blade.php
+++ b/resources/views/errors/402.blade.php
@@ -1,5 +1,0 @@
-@extends('errors::layout')
-
-@section('title', __('Payment Required'))
-@section('code', '402')
-@section('message', __('Payment Required'))

--- a/resources/views/errors/403.blade.php
+++ b/resources/views/errors/403.blade.php
@@ -1,0 +1,5 @@
+@extends('errors::layout')
+
+@section('title', __('Forbidden'))
+@section('code', '403')
+@section('message', __($exception->getMessage() ?: 'Forbidden'))

--- a/resources/views/errors/403.blade.php
+++ b/resources/views/errors/403.blade.php
@@ -2,4 +2,7 @@
 
 @section('title', __('Forbidden'))
 @section('code', '403')
-@section('message', __($exception->getMessage() ?: 'Forbidden'))
+@section('message', __($exception->getMessage() ?: 'You don\'t have permission to access this page.'))
+@section('actions')
+    <a href="{{ url()->previous(route('web.home.index')) }}" title="Go Back">Go Back</a>
+@endsection

--- a/resources/views/errors/403.blade.php
+++ b/resources/views/errors/403.blade.php
@@ -2,7 +2,7 @@
 
 @section('title', __('Forbidden'))
 @section('code', '403')
-@section('message', __($exception->getMessage() ?: 'You don\'t have permission to access this page.'))
+@section('message', __('You don\'t have permission to access this page.'))
 @section('actions')
     <a href="{{ url()->previous(route('web.home.index')) }}" title="Go Back">Go Back</a>
 @endsection

--- a/resources/views/errors/404.blade.php
+++ b/resources/views/errors/404.blade.php
@@ -1,0 +1,5 @@
+@extends('errors::layout')
+
+@section('title', __('Not Found'))
+@section('code', '404')
+@section('message', __('Not Found'))

--- a/resources/views/errors/404.blade.php
+++ b/resources/views/errors/404.blade.php
@@ -1,5 +1,11 @@
 @extends('errors::layout')
 
-@section('title', __('Not Found'))
+@section('title', __('Page Not Found'))
 @section('code', '404')
-@section('message', __('Not Found'))
+@section('message')
+    <p>The page you are looking for could not be found.</p>
+    <p>It may have moved, or it might no longer exist.</p>
+@endsection
+@section('actions')
+    <a href="{{ url()->previous(route('web.home.index')) }}" title="Go Back">Go Back</a>
+@endsection

--- a/resources/views/errors/405.blade.php
+++ b/resources/views/errors/405.blade.php
@@ -1,0 +1,11 @@
+@extends('errors::layout')
+
+@section('title', __('Method Not Allowed'))
+@section('code', '405')
+@section('message')
+    <p>The resource you're trying to access exists, but you can't access it via this method.</p>
+    <p>Please try again.</p>
+@endsection
+@section('actions')
+    <a href="{{ url()->previous(route('web.home.index')) }}" title="Go Back">Go Back</a>
+@endsection

--- a/resources/views/errors/419.blade.php
+++ b/resources/views/errors/419.blade.php
@@ -1,0 +1,5 @@
+@extends('errors::layout')
+
+@section('title', __('Page Expired'))
+@section('code', '419')
+@section('message', __('Page Expired'))

--- a/resources/views/errors/419.blade.php
+++ b/resources/views/errors/419.blade.php
@@ -2,4 +2,7 @@
 
 @section('title', __('Page Expired'))
 @section('code', '419')
-@section('message', __('Page Expired'))
+@section('message', 'The page has expired.')
+@section('actions')
+    <a href="{{ url()->previous(route('web.home.index')) }}" title="Go Back">Go Back</a>
+@endsection

--- a/resources/views/errors/429.blade.php
+++ b/resources/views/errors/429.blade.php
@@ -1,0 +1,5 @@
+@extends('errors::layout')
+
+@section('title', __('Too Many Requests'))
+@section('code', '429')
+@section('message', __('Too Many Requests'))

--- a/resources/views/errors/429.blade.php
+++ b/resources/views/errors/429.blade.php
@@ -2,4 +2,10 @@
 
 @section('title', __('Too Many Requests'))
 @section('code', '429')
-@section('message', __('Too Many Requests'))
+@section('message')
+    <p>You've tried to access this page too many times.</p>
+    <p>Please wait for 1 minute then try again.</p>
+@endsection
+@section('actions')
+    <a href="{{ url()->previous(route('web.home.index')) }}" title="Go Back">Go Back</a>
+@endsection

--- a/resources/views/errors/4xx.blade.php
+++ b/resources/views/errors/4xx.blade.php
@@ -1,9 +1,9 @@
 @extends('errors::layout')
 
-@section('title', $exception->getMessage())
+@section('title', 'Bad Request.')
 @section('code', $exception->getStatusCode())
 @section('message')
-    <p>It seems we're experiencing some technical problems.</p>
+    <p>It seems there are some technical problems.</p>
     <p>Please try again later.</p>
 @endsection
 @section('actions')

--- a/resources/views/errors/4xx.blade.php
+++ b/resources/views/errors/4xx.blade.php
@@ -1,6 +1,6 @@
 @extends('errors::layout')
 
-@section('title', 'Bad Request.')
+@section('title', 'Bad Request')
 @section('code', $exception->getStatusCode())
 @section('message')
     <p>It seems there are some technical problems.</p>

--- a/resources/views/errors/4xx.blade.php
+++ b/resources/views/errors/4xx.blade.php
@@ -1,0 +1,11 @@
+@extends('errors::layout')
+
+@section('title', $exception->getMessage())
+@section('code', $exception->getStatusCode())
+@section('message')
+    <p>It seems we're experiencing some technical problems.</p>
+    <p>Please try again later.</p>
+@endsection
+@section('actions')
+    <a href="{{ url()->previous(route('web.home.index')) }}" title="Go Back">Go Back</a>
+@endsection

--- a/resources/views/errors/500.blade.php
+++ b/resources/views/errors/500.blade.php
@@ -1,0 +1,5 @@
+@extends('errors::layout')
+
+@section('title', __('Server Error'))
+@section('code', '500')
+@section('message', __('Server Error'))

--- a/resources/views/errors/500.blade.php
+++ b/resources/views/errors/500.blade.php
@@ -1,5 +1,11 @@
 @extends('errors::layout')
 
-@section('title', __('Server Error'))
+@section('title', __('Internal Server Error'))
 @section('code', '500')
-@section('message', __('Server Error'))
+@section('message')
+    <p>It seems we're experiencing some technical problems.</p>
+    <p>Please try again later.</p>
+@endsection
+@section('actions')
+    <a href="{{ url()->previous(route('web.home.index')) }}" title="Go Back">Go Back</a>
+@endsection

--- a/resources/views/errors/503.blade.php
+++ b/resources/views/errors/503.blade.php
@@ -1,0 +1,5 @@
+@extends('errors::layout')
+
+@section('title', __('Service Unavailable'))
+@section('code', '503')
+@section('message', __('Service Unavailable'))

--- a/resources/views/errors/503.blade.php
+++ b/resources/views/errors/503.blade.php
@@ -3,7 +3,7 @@
 @section('title', __('Service Unavailable'))
 @section('code', '503')
 @section('message')
-    <p>This portal is temporarily unavailable because we're currently performing maintenance on our systems.</p>
+    <p>This website is temporarily unavailable because we're currently performing maintenance on our systems.</p>
     <p>Please check back again later.</p>
     <p>Sorry for any inconvenience.</p>
 @endsection

--- a/resources/views/errors/503.blade.php
+++ b/resources/views/errors/503.blade.php
@@ -2,4 +2,11 @@
 
 @section('title', __('Service Unavailable'))
 @section('code', '503')
-@section('message', __('Service Unavailable'))
+@section('message')
+    <p>This portal is temporarily unavailable because we're currently performing maintenance on our systems.</p>
+    <p>Please check back again later.</p>
+    <p>Sorry for any inconvenience.</p>
+@endsection
+@section('actions')
+    <a href="{{ url()->previous(route('web.home.index')) }}" title="Go Back">Go Back</a>
+@endsection

--- a/resources/views/errors/5xx.blade.php
+++ b/resources/views/errors/5xx.blade.php
@@ -1,0 +1,11 @@
+@extends('errors::layout')
+
+@section('title', $exception->getMessage())
+@section('code', $exception->getStatusCode())
+@section('message')
+    <p>It seems we're experiencing some technical problems.</p>
+    <p>Please try again later.</p>
+@endsection
+@section('actions')
+    <a href="{{ url()->previous(route('web.home.index')) }}" title="Go Back">Go Back</a>
+@endsection

--- a/resources/views/errors/5xx.blade.php
+++ b/resources/views/errors/5xx.blade.php
@@ -1,9 +1,9 @@
 @extends('errors::layout')
 
-@section('title', $exception->getMessage())
+@section('title', 'Internal Server Error.')
 @section('code', $exception->getStatusCode())
 @section('message')
-    <p>It seems we're experiencing some technical problems.</p>
+    <p>It seems there are some technical problems.</p>
     <p>Please try again later.</p>
 @endsection
 @section('actions')

--- a/resources/views/errors/5xx.blade.php
+++ b/resources/views/errors/5xx.blade.php
@@ -3,7 +3,7 @@
 @section('title', 'Internal Server Error.')
 @section('code', $exception->getStatusCode())
 @section('message')
-    <p>It seems there are some technical problems.</p>
+    <p>It seems we're experiencing some technical problems.</p>
     <p>Please try again later.</p>
 @endsection
 @section('actions')

--- a/resources/views/errors/layout.blade.php
+++ b/resources/views/errors/layout.blade.php
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+
+        <title>@yield('title')</title>
+
+        {{-- todo: styles or link to specific errors stylesheet here when got designs. Will also need to add classes to buttons etc in error views. --}}
+
+    </head>
+    <body>
+        <h1>
+            @yield('code') - @yield('title')
+        </h1>
+        <div>
+            @yield('message')
+        </div>
+        <div>
+            @yield('actions')
+        </div>
+    </body>
+</html>


### PR DESCRIPTION
This is for the error pages HTML and text without styling. The error pages were generated via Laravel's default error page templates - https://laravel.com/docs/10.x/errors#custom-http-error-pages - with some customisations made. I also used the text from CtrlCloud 2's error pages for inspiration. There are `4xx.blade.php` and `5xx.blade.php` files for any errors not covered by the individual files.

There is no styling and we may come back here later when we have designs to change how the pages look. However, for now this is good and minimal. 