### PR TITLE
Auth user logic flaw

### DIFF
--- a/app/Actions/Enquiries/CreateAction.php
+++ b/app/Actions/Enquiries/CreateAction.php
@@ -25,18 +25,18 @@ class CreateAction
     public function handle(
         Tenant $tenant,
         Widget $widget,
+        string|null $message,
+        bool $canContact,
         User $user = null,
-        string|null $message = null,
-        bool $canContact = false
     ): Enquiry {
         $enquiry = new Enquiry();
-        if ($user) {
-            $enquiry->user()->associate($user);
-        }
         $enquiry->tenant = $tenant;
         $enquiry->widget = $widget;
         $enquiry->message = $message;
         $enquiry->can_contact = $canContact;
+        if ($user) {
+            $enquiry->user()->associate($user);
+        }
         $enquiry->save();
 
         return $enquiry;

--- a/app/Actions/Enquiries/CreateAction.php
+++ b/app/Actions/Enquiries/CreateAction.php
@@ -18,17 +18,25 @@ class CreateAction
      * @param Tenant $tenant
      * @param Widget $widget
      * @param User|null $user
+     * @param string|null $message
+     * @param bool $canContact
      * @return Enquiry
      */
-    public function handle(Tenant $tenant, Widget $widget, User $user = null): Enquiry
-    {
+    public function handle(
+        Tenant $tenant,
+        Widget $widget,
+        User $user = null,
+        string|null $message = null,
+        bool $canContact = false
+    ): Enquiry {
         $enquiry = new Enquiry();
         if ($user) {
             $enquiry->user()->associate($user);
         }
         $enquiry->tenant = $tenant;
         $enquiry->widget = $widget;
-        $enquiry->can_contact = false;
+        $enquiry->message = $message;
+        $enquiry->can_contact = $canContact;
         $enquiry->save();
 
         return $enquiry;

--- a/app/Actions/Enquiries/CreateAction.php
+++ b/app/Actions/Enquiries/CreateAction.php
@@ -25,9 +25,9 @@ class CreateAction
     public function handle(
         Tenant $tenant,
         Widget $widget,
-        string|null $message,
+        ?string $message,
         bool $canContact,
-        User $user = null,
+        ?User $user,
     ): Enquiry {
         $enquiry = new Enquiry();
         $enquiry->tenant = $tenant;

--- a/app/Http/Controllers/Web/SpaceCalculator/InputsController.php
+++ b/app/Http/Controllers/Web/SpaceCalculator/InputsController.php
@@ -47,6 +47,8 @@ class InputsController extends WebController
             $this->tenantManager->getCurrentTenant(),
             Widget::SPACE_CALCULATOR,
             Auth::user(),
+            $request->filled('message') ? $request->input('message') : null,
+            $request->filled('can_contact') && $request->boolean('can_contact'),
         );
 
         $input = CreateSpaceCalculatorInputAction::run(

--- a/app/Http/Controllers/Web/SpaceCalculator/InputsController.php
+++ b/app/Http/Controllers/Web/SpaceCalculator/InputsController.php
@@ -60,8 +60,6 @@ class InputsController extends WebController
             Collaboration::from($request->input('collaboration')),
         );
 
-        // todo: discuss - what should we do if this is already set?
-        // (user may have pressed back button and submitted again) Or just reset it?
         Session::put(config('widgets.space-calculator.input-session-key'), $input->uuid);
 
         return redirect()->route('web.space-calculator.outputs.summary', $input);

--- a/app/Http/Controllers/Web/SpaceCalculator/InputsController.php
+++ b/app/Http/Controllers/Web/SpaceCalculator/InputsController.php
@@ -46,9 +46,9 @@ class InputsController extends WebController
         $enquiry = CreateEnquiryAction::run(
             $this->tenantManager->getCurrentTenant(),
             Widget::SPACE_CALCULATOR,
+            Auth::check() && $request->filled('message') ? $request->input('message') : null,
+            Auth::check() && $request->filled('can_contact') && $request->boolean('can_contact'),
             Auth::user(),
-            $request->filled('message') ? $request->input('message') : null,
-            $request->filled('can_contact') && $request->boolean('can_contact'),
         );
 
         $input = CreateSpaceCalculatorInputAction::run(

--- a/app/Http/Middleware/GuardSpaceCalculatorSummaryOutput.php
+++ b/app/Http/Middleware/GuardSpaceCalculatorSummaryOutput.php
@@ -18,20 +18,20 @@ class GuardSpaceCalculatorSummaryOutput
      */
     public function handle(Request $request, Closure $next): Response
     {
+        /**
+         * @var SpaceCalculatorInput $spaceCalculatorInput
+         */
+        $spaceCalculatorInput = $request->route()?->parameter('spaceCalculatorInput');
+
         if (Auth::check()) {
-            return redirect(route('web.portal.index'));
+            return redirect(route('web.space-calculator.outputs.detailed', $spaceCalculatorInput));
         }
 
         if (!Session::has(config('widgets.space-calculator.input-session-key'))) {
             return redirect(route('web.space-calculator.index'));
         }
 
-        /**
-         * @var SpaceCalculatorInput $model
-         */
-        $model = $request->route()?->parameter('spaceCalculatorInput');
-
-        if (Session::get(config('widgets.space-calculator.input-session-key')) !== $model->uuid) {
+        if (Session::get(config('widgets.space-calculator.input-session-key')) !== $spaceCalculatorInput->uuid) {
             return redirect(route('web.space-calculator.index'));
         }
 

--- a/app/Http/Requests/Web/SpaceCalculator/Inputs/PostIndexRequest.php
+++ b/app/Http/Requests/Web/SpaceCalculator/Inputs/PostIndexRequest.php
@@ -30,13 +30,6 @@ class PostIndexRequest extends FormRequest
             'desk_percentage' => ['required', 'integer', 'min:0', 'max:2147483647'],
         ];
 
-        /* todo: discuss - is there a better way to do this? I know you can do the following URL but that doesn't seem
-        appropriate? I want to merge these rules in with the rules above only if the user is logged in
-        https://laravel.com/docs/10.x/validation#performing-additional-validation-on-form-requests
-
-        Or perhaps they could be included above anyway because they are nullable?
-         */
-
         if (Auth::check()) {
             $rules['message'] = ['nullable', 'string', 'max:65535'];
             $rules['can_contact'] = ['nullable', 'boolean'];

--- a/app/Http/Requests/Web/SpaceCalculator/Inputs/PostIndexRequest.php
+++ b/app/Http/Requests/Web/SpaceCalculator/Inputs/PostIndexRequest.php
@@ -7,6 +7,7 @@ use App\Enums\Widgets\SpaceCalculator\HybridWorking;
 use App\Enums\Widgets\SpaceCalculator\Mobility;
 use App\Enums\Widgets\SpaceCalculator\Workstyle;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Validation\Rule;
 use Illuminate\Validation\Rules\Enum;
 
@@ -19,7 +20,7 @@ class PostIndexRequest extends FormRequest
      */
     public function rules(): array
     {
-        return [
+        $rules = [
             'workstyle' => ['required', Rule::enum(Workstyle::class)],
             'hybrid_working' => ['required', Rule::enum(HybridWorking::class)],
             'mobility' => ['required', Rule::enum(Mobility::class)],
@@ -28,5 +29,19 @@ class PostIndexRequest extends FormRequest
             'growth_percentage' => ['required', 'integer', 'min:0', 'max:2147483647'],
             'desk_percentage' => ['required', 'integer', 'min:0', 'max:2147483647'],
         ];
+
+        /* todo: discuss - is there a better way to do this? I know you can do the following URL but that doesn't seem
+        appropriate? I want to merge these rules in with the rules above only if the user is logged in
+        https://laravel.com/docs/10.x/validation#performing-additional-validation-on-form-requests
+
+        Or perhaps they could be included above anyway because they are nullable?
+         */
+
+        if (Auth::check()) {
+            $rules['message'] = ['nullable', 'string', 'max:65535'];
+            $rules['can_contact'] = ['nullable', 'boolean'];
+        }
+
+        return $rules;
     }
 }

--- a/config/mail.php
+++ b/config/mail.php
@@ -94,6 +94,18 @@ return [
 //                'postmark',
 //            ],
 //        ],
+
+        'mailhog' => [
+            'transport' => 'smtp',
+            'url' => env('MAIL_URL'),
+            'host' => env('MAIL_SMTP_HOST', '0.0.0.0'),
+            'port' => env('MAIL_SMTP_PORT', 1025),
+            'encryption' => env('MAIL_SMTP_ENCRYPTION'),
+            'username' => env('MAIL_SMTP_USERNAME'),
+            'password' => env('MAIL_SMTP_PASSWORD'),
+            'timeout' => null,
+            'local_domain' => env('MAIL_SMTP_EHLO_DOMAIN'),
+        ],
     ],
 
     /*

--- a/config/mail.php
+++ b/config/mail.php
@@ -94,18 +94,6 @@ return [
 //                'postmark',
 //            ],
 //        ],
-
-        'mailhog' => [
-            'transport' => 'smtp',
-            'url' => env('MAIL_URL'),
-            'host' => env('MAIL_SMTP_HOST', '0.0.0.0'),
-            'port' => env('MAIL_SMTP_PORT', 1025),
-            'encryption' => env('MAIL_SMTP_ENCRYPTION'),
-            'username' => env('MAIL_SMTP_USERNAME'),
-            'password' => env('MAIL_SMTP_PASSWORD'),
-            'timeout' => null,
-            'local_domain' => env('MAIL_SMTP_EHLO_DOMAIN'),
-        ],
     ],
 
     /*

--- a/resources/views/web/space-calculator/detailed-results.blade.php
+++ b/resources/views/web/space-calculator/detailed-results.blade.php
@@ -2,7 +2,7 @@
 
 @section('page')
 
-   <h1>Space calculator summary results</h1>
+   <h1>Space calculator detailed results</h1>
 
    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean arcu quam, blandit eget sagittis nec, venenatis nec tellus. Cras mollis egestas molestie. Nam elit felis, facilisis eu enim quis, molestie iaculis nisi.</p>
 

--- a/resources/views/web/space-calculator/inputs.blade.php
+++ b/resources/views/web/space-calculator/inputs.blade.php
@@ -51,6 +51,15 @@
             </x-forms.label>
             <x-forms.select name="collaboration" id="collaboration" :selected="old('collaboration')" allowBlank :options="\App\Enums\Widgets\SpaceCalculator\Collaboration::toSelectOptions()" />
         </div>
+        @auth
+            <div>
+                <x-forms.label for="message">Message</x-forms.label>
+                <x-forms.textarea name="message" id="message">{{ old('message') }}</x-forms.textarea>
+            </div>
+            <div>
+                <x-forms.checkbox name="can_contact" id="can_contact" :checked="old('can_contact', false)" value="1">Happy for a consultant to get in touch?</x-forms.checkbox>
+            </div>
+        @endauth
         <button type="submit" title="Get Results">Get Results</button>
     </form>
 

--- a/tests/Feature/Http/Web/SpaceCalculator/InputsController/GetIndexTest.php
+++ b/tests/Feature/Http/Web/SpaceCalculator/InputsController/GetIndexTest.php
@@ -8,9 +8,27 @@ class GetIndexTest extends TestCase
 {
     public function test_page_loads_ok(): void
     {
-        $response = $this->get(route('web.space-calculator.inputs.index'));
+        $this->assertGuest();
 
-        $response->assertOk()
-            ->assertViewIs('web.space-calculator.inputs');
+        $this->get(route('web.space-calculator.inputs.index'))
+            ->assertOk()
+            ->assertViewIs('web.space-calculator.inputs')
+            ->assertDontSeeText([
+                'Message',
+                'Happy for a consultant to get in touch?'
+            ]);
+    }
+
+    public function test_page_loads_ok_for_authenticated_user(): void
+    {
+        $this->authenticateUser();
+
+        $this->get(route('web.space-calculator.inputs.index'))
+            ->assertOk()
+            ->assertViewIs('web.space-calculator.inputs')
+            ->assertSeeText([
+                'Message',
+                'Happy for a consultant to get in touch?'
+            ]);
     }
 }

--- a/tests/Feature/Http/Web/SpaceCalculator/InputsController/PostIndexTest.php
+++ b/tests/Feature/Http/Web/SpaceCalculator/InputsController/PostIndexTest.php
@@ -12,12 +12,15 @@ use App\Enums\Widgets\SpaceCalculator\Mobility;
 use App\Enums\Widgets\SpaceCalculator\Workstyle;
 use App\Models\Enquiry;
 use App\Models\SpaceCalculatorInput;
+use App\Models\User;
 use Tests\TestCase;
 
 class PostIndexTest extends TestCase
 {
-    public function test_can_post_inputs_and_creates_one_enquiry_and_one_input(): void
+    public function test_can_post_as_guest_inputs_and_creates_one_enquiry_and_one_input(): void
     {
+        $this->assertGuest();
+
         CreateEnquiryAction::shouldRun()
             ->once()
             ->with(
@@ -51,7 +54,52 @@ class PostIndexTest extends TestCase
             'hybrid_working' => HybridWorking::THREE_DAYS->value,
             'mobility' => Mobility::COMPUTER_MIXTURE->value,
             'collaboration' => Collaboration::MANY_MEETINGS->value,
-        ])->assertRedirect()
+        ])->assertRedirect(route('web.space-calculator.outputs.summary', $input))
+            ->assertSessionHasNoErrors()
+            ->assertSessionHas(config('widgets.space-calculator.input-session-key'), $input->uuid);
+    }
+
+    public function test_can_post_as_authenticated_user_inputs_and_creates_one_enquiry_and_one_input(): void
+    {
+        $user = User::factory()->create();
+        $this->authenticateUser($user);
+
+        CreateEnquiryAction::shouldRun()
+            ->once()
+            ->with(
+                Tenant::WFG,
+                Widget::SPACE_CALCULATOR,
+                $user,
+                'Lorem ipsum dolor sit amet',
+                true,
+            )
+            ->andReturn($enquiry = Enquiry::factory()->create());
+
+        CreateSpaceCalculatorInputAction::shouldRun()
+            ->once()
+            ->with(
+                $enquiry,
+                Workstyle::FINANCIAL,
+                8,
+                40,
+                25,
+                HybridWorking::THREE_DAYS,
+                Mobility::COMPUTER_MIXTURE,
+                Collaboration::MANY_MEETINGS,
+            )
+            ->andReturn($input = SpaceCalculatorInput::factory()->create());
+
+        $this->post(route('web.space-calculator.inputs.post'), [
+            'workstyle' => Workstyle::FINANCIAL->value,
+            'total_people' => 8,
+            'growth_percentage' => 40,
+            'desk_percentage' => 25,
+            'hybrid_working' => HybridWorking::THREE_DAYS->value,
+            'mobility' => Mobility::COMPUTER_MIXTURE->value,
+            'collaboration' => Collaboration::MANY_MEETINGS->value,
+            'message' => 'Lorem ipsum dolor sit amet',
+            'can_contact' => true,
+        ])->assertRedirect(route('web.space-calculator.outputs.summary', $input))
             ->assertSessionHasNoErrors()
             ->assertSessionHas(config('widgets.space-calculator.input-session-key'), $input->uuid);
     }
@@ -97,6 +145,37 @@ class PostIndexTest extends TestCase
                 'hybrid_working',
                 'mobility',
                 'collaboration',
+            ])->assertSessionMissing(config('widgets.space-calculator.input-session-key'));
+    }
+
+    public function test_other_errors_for_authenticated_user(): void
+    {
+        $user = User::factory()->create();
+        $this->authenticateUser($user);
+
+        CreateEnquiryAction::shouldNotRun();
+        CreateSpaceCalculatorInputAction::shouldNotRun();
+
+        $this->post(route('web.space-calculator.inputs.post'), [
+            'workstyle' => 'super_efficient',
+            'total_people' => 'eight',
+            'growth_percentage' => 'a lot',
+            'desk_percentage' => 'plenty',
+            'hybrid_working' => 'many_days',
+            'mobility' => 'very_mobile',
+            'collaboration' => 'team_work_is_great',
+            'message' => 'This is fine',
+            'can_contact' => 'true',
+        ])->assertRedirect()
+            ->assertSessionHasErrors([
+                'workstyle',
+                'total_people',
+                'growth_percentage',
+                'desk_percentage',
+                'hybrid_working',
+                'mobility',
+                'collaboration',
+                'can_contact'
             ])->assertSessionMissing(config('widgets.space-calculator.input-session-key'));
     }
 

--- a/tests/Feature/Http/Web/SpaceCalculator/InputsController/PostIndexTest.php
+++ b/tests/Feature/Http/Web/SpaceCalculator/InputsController/PostIndexTest.php
@@ -69,9 +69,9 @@ class PostIndexTest extends TestCase
             ->with(
                 Tenant::WFG,
                 Widget::SPACE_CALCULATOR,
-                $user,
                 'Lorem ipsum dolor sit amet',
                 true,
+                $user,
             )
             ->andReturn($enquiry = Enquiry::factory()->create());
 

--- a/tests/Feature/Http/Web/SpaceCalculator/InputsController/PostIndexTest.php
+++ b/tests/Feature/Http/Web/SpaceCalculator/InputsController/PostIndexTest.php
@@ -24,6 +24,8 @@ class PostIndexTest extends TestCase
                 Tenant::WFG,
                 Widget::SPACE_CALCULATOR,
                 null,
+                null,
+                false,
             )
             ->andReturn($enquiry = Enquiry::factory()->create());
 

--- a/tests/Feature/Http/Web/SpaceCalculator/OutputsController/GetSummaryTest.php
+++ b/tests/Feature/Http/Web/SpaceCalculator/OutputsController/GetSummaryTest.php
@@ -66,7 +66,7 @@ class GetSummaryTest extends TestCase
 
         $this->withSession([config('widgets.space-calculator.input-session-key') => $inputs->uuid])
             ->get(route('web.space-calculator.outputs.summary', $inputs->uuid))
-            ->assertRedirect(route('web.portal.index'));
+            ->assertRedirect(route('web.space-calculator.outputs.detailed', $inputs));
     }
 
     public function test_without_session_redirects_away(): void

--- a/tests/Feature/Http/Web/SpaceCalculator/OutputsController/PostSummaryTest.php
+++ b/tests/Feature/Http/Web/SpaceCalculator/OutputsController/PostSummaryTest.php
@@ -147,10 +147,10 @@ class PostSummaryTest extends TestCase
         AttachToUserAction::shouldNotRun();
 
         $this->withSession([config('widgets.space-calculator.input-session-key') => $inputs->uuid])
-            ->post(route('web.space-calculator.outputs.detailed', $inputs), [
+            ->post(route('web.space-calculator.outputs.summary.post', $inputs), [
                 'email' => $this->faker->email,
             ])
-            ->assertRedirect(route('web.portal.index'));
+            ->assertRedirect(route('web.space-calculator.outputs.detailed', $inputs));
 
         Notification::assertCount(0);
     }

--- a/tests/Feature/Http/Web/SpaceCalculator/OutputsController/PostSummaryTest.php
+++ b/tests/Feature/Http/Web/SpaceCalculator/OutputsController/PostSummaryTest.php
@@ -147,7 +147,7 @@ class PostSummaryTest extends TestCase
         AttachToUserAction::shouldNotRun();
 
         $this->withSession([config('widgets.space-calculator.input-session-key') => $inputs->uuid])
-            ->post(route('web.space-calculator.outputs.summary.post', $inputs), [
+            ->post(route('web.space-calculator.outputs.detailed', $inputs), [
                 'email' => $this->faker->email,
             ])
             ->assertRedirect(route('web.portal.index'));

--- a/tests/Unit/Actions/Enquiries/CreateActionTest.php
+++ b/tests/Unit/Actions/Enquiries/CreateActionTest.php
@@ -21,7 +21,9 @@ class CreateActionTest extends TestCase
         $enquiry = CreateAction::run(
             Tenant::WFG,
             Widget::SPACE_CALCULATOR,
-            null
+            null,
+            false,
+            null,
         );
 
         $this->assertEquals(1, Enquiry::count());
@@ -46,6 +48,8 @@ class CreateActionTest extends TestCase
         $enquiry = CreateAction::run(
             Tenant::WFG,
             Widget::SPACE_CALCULATOR,
+            null,
+            false,
             $user_2,
         );
 
@@ -63,9 +67,9 @@ class CreateActionTest extends TestCase
         $enquiry = CreateAction::run(
             Tenant::WFG,
             Widget::SPACE_CALCULATOR,
-            null,
             'Lorem ipsum dolor sit amet',
             true,
+            null,
         );
 
         $this->assertEquals(1, Enquiry::count());

--- a/tests/Unit/Actions/Enquiries/CreateActionTest.php
+++ b/tests/Unit/Actions/Enquiries/CreateActionTest.php
@@ -29,6 +29,7 @@ class CreateActionTest extends TestCase
         $this->assertNull($enquiry->user_id);
         $this->assertEquals(Tenant::WFG, $enquiry->tenant);
         $this->assertEquals(Widget::SPACE_CALCULATOR, $enquiry->widget);
+        $this->assertNull($enquiry->message);
         $this->assertFalse($enquiry->can_contact);
     }
 
@@ -50,5 +51,29 @@ class CreateActionTest extends TestCase
 
         $this->assertEquals(1, Enquiry::count());
         $this->assertEquals($user_2->id, $enquiry->user_id);
+    }
+
+    public function test_enquiry_is_created_and_returned_with_extra_optional_fields(): void
+    {
+        $this->assertEquals(0, Enquiry::count());
+
+        /**
+         * @var Enquiry $enquiry
+         */
+        $enquiry = CreateAction::run(
+            Tenant::WFG,
+            Widget::SPACE_CALCULATOR,
+            null,
+            'Lorem ipsum dolor sit amet',
+            true,
+        );
+
+        $this->assertEquals(1, Enquiry::count());
+
+        $this->assertNull($enquiry->user_id);
+        $this->assertEquals(Tenant::WFG, $enquiry->tenant);
+        $this->assertEquals(Widget::SPACE_CALCULATOR, $enquiry->widget);
+        $this->assertEquals('Lorem ipsum dolor sit amet', $enquiry->message);
+        $this->assertTrue($enquiry->can_contact);
     }
 }


### PR DESCRIPTION
This PR includes some additions for authenticated users on the "get started" / inputs page. They can now enter a message and choose whether to be contacted or not. On submit of the form they are redirected to the summary page which then redirects them to the detailed page via the middleware. This solves the problem of the message and contactable boolean never getting entered by an authenticated user. The "complete profile" issue is no longer an issue due to the card / PR completed / merged in beforehand.

There are some questions in the code as normal.